### PR TITLE
server: inject algoHost into algoServer

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ module.exports = class HFServer {
     db,
     apiKey,
     apiSecret,
+    db,
     agent,
     port,
     dsPort,
@@ -26,17 +27,17 @@ module.exports = class HFServer {
   } = {}) {
     this._dsPort = dsPort
     this._asPort = asPort
+    this._db = db
 
     if (_isFinite(dsPort)) {
       debug('spawning data server on port %d', dsPort)
-
       this.ds = new DataServer({
-        db,
         port: dsPort,
         proxy,
         transform,
         apiKey,
         apiSecret,
+        db: this._db,
         agent,
         restURL,
         wsURL,
@@ -54,6 +55,7 @@ module.exports = class HFServer {
         port: asPort,
         apiKey,
         apiSecret,
+        db: this._db,
         agent,
         wsURL,
         restURL,

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,11 +2,13 @@
 
 const _isFinite = require('lodash/isFinite')
 const debug = require('debug')('bfx:hf:server')
-const { AccumulateDistribute, TWAP, Iceberg, PingPong } = require('bfx-hf-algo')
+const { AccumulateDistribute, TWAP, Iceberg, PingPong, AOHost } = require('bfx-hf-algo')
 const AOServer = require('bfx-hf-algo-server')
 const DataServer = require('bfx-hf-data-server')
 const { nonce } = require('bfx-api-node-util')
 const WS = require('ws')
+
+const DEFAULT_DEFINITIONS = [AccumulateDistribute, TWAP, Iceberg, PingPong]
 
 module.exports = class HFServer {
   constructor({
@@ -43,10 +45,12 @@ module.exports = class HFServer {
 
     if (_isFinite(asPort)) {
       debug('spawning algo server on port %d', asPort)
+      this.algoHost = new AOHost({
+        DEFAULT_DEFINITIONS, apiKey, apiSecret, agent, wsURL, restURL
+      })
 
       this.as = new AOServer({
-        db,
-        aos: [AccumulateDistribute, TWAP, Iceberg, PingPong],
+        aos: null,
         port: asPort,
         apiKey,
         apiSecret,
@@ -54,6 +58,7 @@ module.exports = class HFServer {
         wsURL,
         restURL,
       })
+      this.as.setAlgoHost(this.algoHost)
     }
 
     this.wssClients = {}


### PR DESCRIPTION
Create the algoHost instance seperately and inject it in. This allows us to have more control over the algo order definitions from within the hf-server.