### PR TITLE
Fix: Set affiliate code on outgoing orders

### DIFF
--- a/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
+++ b/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
@@ -15,7 +15,7 @@ module.exports = async (server, apiKey, apiSecret) => {
   const { dbPath, apiDB, d } = server
   const { UserSettings } = apiDB
   const { userSettings: settings } = await UserSettings.getAll()
-  const { dms } = settings
+  const { dms, affiliateCode } = settings
 
   d('spawning bfx algo host (dms %s)', dms ? 'enabled' : 'disabled')
 
@@ -25,6 +25,7 @@ module.exports = async (server, apiKey, apiSecret) => {
       apiSecret,
       dms: dms ? 4 : 0,
       withHeartbeat: true,
+      affiliateCode,
     }),
 
     db: new HFDB({

--- a/lib/ws_servers/api/handlers/on_order_submit.js
+++ b/lib/ws_servers/api/handlers/on_order_submit.js
@@ -9,7 +9,8 @@ const submitOrderBitfinex = require('../submit_order_bitfinex')
 const submitOrderBinance = require('../submit_order_binance')
 
 module.exports = async (server, ws, msg) => {
-  const { d } = server
+  const { d, db } = server
+  const { UserSettings } = db
   const [, authToken, exID, packet] = msg
   const validRequest = validateParams(ws, {
     exID: { type: 'string', v: exID },
@@ -31,6 +32,14 @@ module.exports = async (server, ws, msg) => {
 
   switch (exID) {
     case 'bitfinex': {
+      const { userSettings } = await UserSettings.getAll()
+
+      if (!packet.meta) {
+        packet.meta = {}
+      }
+
+      packet.meta.aff_code = userSettings.affiliateCode // eslint-disable-line
+
       await submitOrderBitfinex(d, ws, ws.clients.bitfinex, packet)
       break
     }


### PR DESCRIPTION
Populates affiliate code on all outgoing orders (AOs and atomics)

Needs:
https://github.com/bitfinexcom/bfx-api-node-models/pull/34
https://github.com/bitfinexcom/bfx-hf-ext-plugin-bitfinex/pull/9