### PR TITLE
Feature: Support Bitfinex UCM Notify 2.0.6

### DIFF
--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const _isObject = require('lodash/isObject')
+const _isString = require('lodash/isString')
+const _isEmpty = require('lodash/isEmpty')
 const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
 const BitfinexExchangeConnection = require('../../exchange_clients/bitfinex')
 const { notifyInfo, notifyError, notifySuccess } = require('../../util/ws/notify')
@@ -87,14 +90,22 @@ module.exports = async (ws, apiKey, apiSecret, db, d) => {
       }
 
       case 'n': {
-        const [,,,,,, status, text] = msgData
+        let [,,,, ucmPayload,, status, text] = msgData
 
-        if (status === 'SUCCESS') {
-          notifySuccess(ws, text)
-        } else if (status === 'INFO') {
-          notifyInfo(ws, text)
-        } else if (status === 'ERROR') {
-          notifyError(ws, text)
+        // The payload is fluid and can have any format; HF uses level & message
+        if (_isObject(ucmPayload) && !_isEmpty(ucmPayload)) {
+          status = ucmPayload.level || ucmPayload.type || ucmPayload.status
+          text = ucmPayload.message || ucmPayload.msg || ucmPayload.text
+        }
+
+        if (_isString(status) && _isString(text) && !_isEmpty(status) && !_isEmpty(text)) {
+          if (status.toLowerCase() === 'success') {
+            notifySuccess(ws, text)
+          } else if (status.toLowerCase() === 'info') {
+            notifyInfo(ws, text)
+          } else if (status.toLowerCase() === 'error') {
+            notifyError(ws, text)
+          }
         }
 
         break

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds support for forwarding bitfinex ucm notifications as ordinary notifications; previously they were not parsed. This forwards messages like minimum size errors to the user, closes https://github.com/f3rno/bfx-hf-ui/issues/51