### PR TITLE
[WIP] Fix: Use relative paths in tests & move AOServer (for UI) spawn location 2.0.8

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ module.exports = ({
     adapter: HFDBLowDBAdapter({ dbPath: uiDBPath })
   })
 
+  const as = new AlgoServer({
+    port: algoServerPort,
+    hfLowDBPath: algoDBPath,
+    apiDB
+  })
+
   let dsBitfinex = null
   let dsBinance = null
 
@@ -84,6 +90,7 @@ module.exports = ({
   })
 
   syncMarkets(apiDB, EXAS).then(() => {
+    as.open()
     exPool.open()
 
     if (dsBinance) {

--- a/lib/util/init_ao_host.js
+++ b/lib/util/init_ao_host.js
@@ -2,7 +2,6 @@
 
 const _isFunction = require('lodash/isFunction')
 const { AOHost } = require('bfx-hf-algo')
-const AOServer = require('bfx-hf-algo-server')
 
 const {
   PingPong, Iceberg, TWAP, AccumulateDistribute, MACrossover, OCOCO
@@ -16,15 +15,8 @@ module.exports = async ({ adapter, db, initCB }) => {
   const host = new AOHost({
     db,
     adapter,
-    aos: algoOrders,
+    aos: algoOrders
   })
-  // added for communication with bitfinex webform
-  const server = new AOServer({
-    db,
-    adapter,
-    aos: null
-  })
-  server.setAlgoHost(host)
 
   if (_isFunction(initCB)) {
     await initCB(host)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",

--- a/test/integration/ex_pool/recv_bitfinex_data.js
+++ b/test/integration/ex_pool/recv_bitfinex_data.js
@@ -9,4 +9,4 @@ testPoolExRecvData('bitfinex', [
   { wsID: 'tETHUSD' },
   { wsID: 'tLTCUSD' },
   { wsID: 'tEOSUSD' }
-], 20000)
+], 60000)

--- a/test/integration/util/test_pool_recv_data.js
+++ b/test/integration/util/test_pool_recv_data.js
@@ -3,10 +3,10 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolReset = require('ex_pool/reset')
-const poolSubscribe = require('ex_pool/subscribe')
-const poolAddDataListener = require('ex_pool/add_data_listener')
+const poolInit = require('../../../lib/ex_pool')
+const poolReset = require('../../../lib/ex_pool/reset')
+const poolSubscribe = require('../../../lib/ex_pool/subscribe')
+const poolAddDataListener = require('../../../lib/ex_pool/add_data_listener')
 
 module.exports = (done, exID, channels, asserters) => {
   const pool = poolInit()

--- a/test/unit/ex_pool/add_client.js
+++ b/test/unit/ex_pool/add_client.js
@@ -4,12 +4,12 @@
 const assert = require('assert')
 const sinon = require('sinon')
 
-const capture = require('capture')
-const poolInit = require('ex_pool')
-const poolReset = require('ex_pool/reset')
-const poolAddClient = require('ex_pool/add_client')
-const poolHasClient = require('ex_pool/has_client')
-const bfx = require('exchange_clients/bitfinex')
+const capture = require('../../../lib/capture')
+const poolInit = require('../../../lib/ex_pool')
+const poolReset = require('../../../lib/ex_pool/reset')
+const poolAddClient = require('../../../lib/ex_pool/add_client')
+const poolHasClient = require('../../../lib/ex_pool/has_client')
+const bfx = require('../../../lib/exchange_clients/bitfinex')
 
 describe('ex_pool: add_client', () => {
   it('validates the exchange id', () => {

--- a/test/unit/ex_pool/add_data_listener.js
+++ b/test/unit/ex_pool/add_data_listener.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolAddDataListener = require('ex_pool/add_data_listener')
+const poolInit = require('../../../lib/ex_pool')
+const poolAddDataListener = require('../../../lib/ex_pool/add_data_listener')
 
 describe('ex_pool: add_data_listener', () => {
   it('adds the callback to the internal listeners array', () => {

--- a/test/unit/ex_pool/clear_sub_ref_count.js
+++ b/test/unit/ex_pool/clear_sub_ref_count.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolClearSubRefCount = require('ex_pool/clear_sub_ref_count')
+const poolInit = require('../../../lib/ex_pool')
+const poolClearSubRefCount = require('../../../lib/ex_pool/clear_sub_ref_count')
 
 describe('ex_pool: clear_sub_ref_count', () => {
   it('clears the subscription ref count for the exchange/channel pair', () => {

--- a/test/unit/ex_pool/decrement_sub_ref_count.js
+++ b/test/unit/ex_pool/decrement_sub_ref_count.js
@@ -4,9 +4,9 @@
 const assert = require('assert')
 const sinon = require('sinon')
 
-const poolInit = require('ex_pool')
-const poolDecrementSubRefCount = require('ex_pool/decrement_sub_ref_count')
-const capture = require('capture')
+const poolInit = require('../../../lib/ex_pool')
+const poolDecrementSubRefCount = require('../../../lib/ex_pool/decrement_sub_ref_count')
+const capture = require('../../../lib/capture')
 
 describe('ex_pool: decrement_sub_ref_count', () => {
   it('decrements the subscription ref count for the exchange/channel pair', () => {

--- a/test/unit/ex_pool/get_client.js
+++ b/test/unit/ex_pool/get_client.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolGetClient = require('ex_pool/get_client')
+const poolInit = require('../../../lib/ex_pool')
+const poolGetClient = require('../../../lib/ex_pool/get_client')
 
 describe('ex_pool: get_client', () => {
   it('returns exchange client by ID', () => {

--- a/test/unit/ex_pool/get_sub_ref_count.js
+++ b/test/unit/ex_pool/get_sub_ref_count.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolGetSubRefCount = require('ex_pool/get_sub_ref_count')
+const poolInit = require('../../../lib/ex_pool')
+const poolGetSubRefCount = require('../../../lib/ex_pool/get_sub_ref_count')
 
 describe('ex_pool: get_sub_ref_count', () => {
   it('returns the subscription reference count', () => {

--- a/test/unit/ex_pool/has_client.js
+++ b/test/unit/ex_pool/has_client.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolHasClient = require('ex_pool/has_client')
+const poolInit = require('../../../lib/ex_pool')
+const poolHasClient = require('../../../lib/ex_pool/has_client')
 
 describe('ex_pool: has_client', () => {
   it('returns true if the pool has the requested client', () => {

--- a/test/unit/ex_pool/increment_sub_ref_count.js
+++ b/test/unit/ex_pool/increment_sub_ref_count.js
@@ -3,9 +3,9 @@
 
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolGetSubRefCount = require('ex_pool/get_sub_ref_count')
-const poolIncrementSubRefCount = require('ex_pool/increment_sub_ref_count')
+const poolInit = require('../../../lib/ex_pool')
+const poolGetSubRefCount = require('../../../lib/ex_pool/get_sub_ref_count')
+const poolIncrementSubRefCount = require('../../../lib/ex_pool/increment_sub_ref_count')
 
 describe('ex_pool: has_client', () => {
   it('initializes the reference counter with 0 if needed', () => {

--- a/test/unit/ex_pool/init.js
+++ b/test/unit/ex_pool/init.js
@@ -6,7 +6,7 @@ const _isArray = require('lodash/isArray')
 const _isObject = require('lodash/isObject')
 const _isFunction = require('lodash/isFunction')
 
-const poolInit = require('ex_pool')
+const poolInit = require('../../../lib/ex_pool')
 
 describe('ex_pool: init', () => {
   it('constructs a pool object', () => {

--- a/test/unit/ex_pool/propagate_data.js
+++ b/test/unit/ex_pool/propagate_data.js
@@ -4,9 +4,9 @@
 const sinon = require('sinon')
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolPropagateData = require('ex_pool/propagate_data')
-const poolAddDataListener = require('ex_pool/add_data_listener')
+const poolInit = require('../../../lib/ex_pool')
+const poolPropagateData = require('../../../lib/ex_pool/propagate_data')
+const poolAddDataListener = require('../../../lib/ex_pool/add_data_listener')
 
 describe('ex_pool: propagate_data', () => {
   it('passes the channel identifier and data to all data listeners', () => {

--- a/test/unit/ex_pool/reset.js
+++ b/test/unit/ex_pool/reset.js
@@ -5,8 +5,8 @@ const sinon = require('sinon')
 const assert = require('assert')
 const _isEmpty = require('lodash/isEmpty')
 
-const poolInit = require('ex_pool')
-const poolReset = require('ex_pool/reset')
+const poolInit = require('../../../lib/ex_pool')
+const poolReset = require('../../../lib/ex_pool/reset')
 
 describe('ex_pool: reset', () => {
   it('closes all exchange client connections', () => {

--- a/test/unit/ex_pool/subscribe.js
+++ b/test/unit/ex_pool/subscribe.js
@@ -4,11 +4,11 @@
 const sinon = require('sinon')
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolReset = require('ex_pool/reset')
-const poolSubscribe = require('ex_pool/subscribe')
-const chanDataToKey = require('util/chan_data_to_key')
-const bfx = require('exchange_clients/bitfinex')
+const poolInit = require('../../../lib/ex_pool')
+const poolReset = require('../../../lib/ex_pool/reset')
+const poolSubscribe = require('../../../lib/ex_pool/subscribe')
+const chanDataToKey = require('../../../lib/util/chan_data_to_key')
+const bfx = require('../../../lib/exchange_clients/bitfinex')
 
 describe('ex_pool: subscribe', () => {
   const channel = ['trades', 'tBTCUSD']

--- a/test/unit/ex_pool/unsubscribe.js
+++ b/test/unit/ex_pool/unsubscribe.js
@@ -4,15 +4,15 @@
 const sinon = require('sinon')
 const assert = require('assert')
 
-const poolInit = require('ex_pool')
-const poolReset = require('ex_pool/reset')
-const poolAddClient = require('ex_pool/add_client')
-const poolSubscribe = require('ex_pool/subscribe')
-const poolUnsubscribe = require('ex_pool/unsubscribe')
-const poolGetSubRefCount = require('ex_pool/get_sub_ref_count')
-const chanDataToKey = require('util/chan_data_to_key')
-const bfx = require('exchange_clients/bitfinex')
-const capture = require('capture')
+const poolInit = require('../../../lib/ex_pool')
+const poolReset = require('../../../lib/ex_pool/reset')
+const poolAddClient = require('../../../lib/ex_pool/add_client')
+const poolSubscribe = require('../../../lib/ex_pool/subscribe')
+const poolUnsubscribe = require('../../../lib/ex_pool/unsubscribe')
+const poolGetSubRefCount = require('../../../lib/ex_pool/get_sub_ref_count')
+const chanDataToKey = require('../../../lib/util/chan_data_to_key')
+const bfx = require('../../../lib/exchange_clients/bitfinex')
+const capture = require('../../../lib/capture')
 
 describe('ex_pool: unsubscribe', () => {
   const channel = ['trades', 'tBTCUSD']


### PR DESCRIPTION
### Fixes:
- [x] use relative paths in tests
- [x] increase timeout for live data test
- [x] moves the `AOServer` instance out of the algo server and back into the startup script

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated

### TODO
- [ ] verify `AOServer` is not affecting DMS flag
