### PR TITLE
Fix duplication of AlgoHost

### DIFF
--- a/lib/util/init_ao_host.js
+++ b/lib/util/init_ao_host.js
@@ -20,13 +20,12 @@ module.exports = async ({ adapter, db, initCB }) => {
   })
 
   // For communication with the official BFX UI
-  const server = new AOServer({
+  new AOServer({
     db,
     adapter,
-    aos: algoOrders
+    aos: algoOrders,
+    host
   })
-
-  server.setAlgoHost(host)
 
   if (_isFunction(initCB)) {
     await initCB(host)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description:

Previously algo orders were being duplicated due to the creation of 2 algo-host instances. This pull request solves that by only initiating a single instance of the AOhost.

Linked to https://github.com/bitfinexcom/bfx-hf-algo-server/pull/19

### Breaking changes:
None

### New features:
None

### Fixes:
- [x] Only create a single instance of a AOhost

### PR status:
- [x] Version bumped
- [x] Change-log updated
