### PR TITLE
log: fix console trace error

### DIFF
--- a/lib/util/ws/send_error.js
+++ b/lib/util/ws/send_error.js
@@ -3,6 +3,6 @@
 const send = require('./send')
 
 module.exports = (ws, msg) => {
-  console.trace(msg)
+  console.error('websocket error:', msg)
   send(ws, ['error', msg])
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
`console.trace` can't handle passed objects / arrays, so we have
to use `console.error` to see the eerror message.

before:

```
[object Object]
    at module.exports (/Users/robert/bitfinex/bfx-hf-server/lib/util/ws/send_error.js:7:11)
    at handleWSMessage.catch (/Users/robert/bitfinex/bfx-hf-server/lib/ws_server.js:75:7)
```

after:

```
websocket error: 500 - ["error",10100,"apikey: digest invalid"]
```