### PR TITLE
fix: do not crash with empty orderbooks

### DIFF
--- a/lib/exchange_clients/bitfinex/recv/data_handlers/book.js
+++ b/lib/exchange_clients/bitfinex/recv/data_handlers/book.js
@@ -10,10 +10,13 @@ const BOOK_PACKET_SEND_INTERVAL_MS = 1000
 module.exports = (exa, msg, channel) => {
   const { books, lastBookPacketSent } = exa
 
-  if (_isArray(_last(msg)[0])) {
-    books[channel.symbol] = _last(msg)
+  const lastElement = _last(msg)
+  const isEmptySnap = _isArray(lastElement) && lastElement.length === 0
+
+  if (_isArray(lastElement[0]) || isEmptySnap) {
+    books[channel.symbol] = lastElement
   } else {
-    OrderBook.updateArrayOBWith(books[channel.symbol], _last(msg))
+    OrderBook.updateArrayOBWith(books[channel.symbol], lastElement)
   }
 
   const lastSend = lastBookPacketSent[channel.symbol]

--- a/test/unit/book.js
+++ b/test/unit/book.js
@@ -1,0 +1,19 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+
+const updateBook = require('../../lib/exchange_clients/bitfinex/recv/data_handlers/book.js')
+
+describe('order books', () => {
+  it('does not crash: empty snapshot and update following', () => {
+    const msg1 = [12282, []]
+    const msg2 = [12295, [4000, 1, -1]]
+
+    const opts = { books: {}, lastBookPacketSent: {} }
+    updateBook(opts, msg1, { symbol: 'tBTCUSD' })
+    updateBook(opts, msg2, { symbol: 'tBTCUSD' })
+
+    assert.deepStrictEqual(opts.books, { tBTCUSD: [[4000, 1, -1]] })
+  })
+})


### PR DESCRIPTION
this fixes an issue in the detection of snapshots. given the
orderbook and snapshot was empty, the app would crash on the next
update, i.e. an order submit