### PR TITLE
paper trading: filter pairs in menu selection

### DIFF
--- a/lib/exchange_clients/bitfinex/get_markets.js
+++ b/lib/exchange_clients/bitfinex/get_markets.js
@@ -4,15 +4,25 @@ const _uniq = require('lodash/uniq')
 const _flatten = require('lodash/flatten')
 const { RESTv2 } = require('bfx-api-node-rest')
 const symbolTransformer = require('./transformers/symbol')
+const filterPairs = require('./util/filter_pairs.js')
 const rest = new RESTv2()
 
-module.exports = () => {
-  return rest.conf([
+module.exports = async () => {
+  const pairs = rest.conf([
     'pub:list:pair:exchange',
     'pub:list:pair:margin',
     'pub:list:pair:futures'
-  ]).then(res => {
-    const symbols = _uniq(_flatten(_flatten(res)))
-    return symbols.map((sym) => symbolTransformer(res, sym))
-  })
+  ])
+
+  const pairsToExclude = rest.conf([
+    'pub:list:currency:paper'
+  ])
+
+  const [res, pp] = await Promise.all([pairs, pairsToExclude])
+  const symbols = _uniq(_flatten(_flatten(res)))
+  const exclude = _flatten(pp)
+
+  const sf = filterPairs(symbols, exclude)
+
+  return sf.map((sym) => symbolTransformer(res, sym))
 }

--- a/lib/exchange_clients/bitfinex/util/filter_pairs.js
+++ b/lib/exchange_clients/bitfinex/util/filter_pairs.js
@@ -1,0 +1,19 @@
+'use strict'
+
+module.exports = function filterPairs (symbols, exclude) {
+  const sf = symbols.filter((el) => {
+    let include = true
+
+    for (let i = 0; i < exclude.length; i++) {
+      const p = exclude[i]
+      if (el.startsWith(p) || el.endsWith(p)) {
+        include = false
+        break
+      }
+    }
+
+    return include
+  })
+
+  return sf
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",

--- a/test/unit/filter_pairs.js
+++ b/test/unit/filter_pairs.js
@@ -1,0 +1,23 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+
+const filterPairs = require('../../lib/exchange_clients/bitfinex/util/filter_pairs.js')
+
+describe('filter pairs', () => {
+  it('filters out paper trading pairs', () => {
+    const exclude = [
+      'AAA', 'BBB', 'TESTBTC', 'TESTBTCF0',
+      'TESTUSD', 'TESTUSDT', 'TESTUSDTF0'
+    ]
+
+    const symbols = [
+      'AAABBB', 'TESTBTCF0:TESTUSDTF0', 'FOO:TESTBTC',
+      'BTCUSD', 'ETHUSD', 'XAUTF0:USTF0'
+    ]
+
+    const res = filterPairs(symbols, exclude)
+    assert.deepStrictEqual(res, ['BTCUSD', 'ETHUSD', 'XAUTF0:USTF0'])
+  })
+})


### PR DESCRIPTION
uses the `pub:list:currency:paper` endpoint to get the current
list of paper pairs, available at:

https://api-pub.bitfinex.com/v2/conf/pub:list:currency:paper

currently filtered:

```
["AAA","BBB","TESTBTC","TESTBTCF0","TESTUSD","TESTUSDT","TESTUSDTF0"]
```
