### PR TITLE
bring in algo-order adapter, enable staging urls

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -8,4 +8,6 @@ startHFServer({
   uiDBPath: `${__dirname}/../db/ui.json`,
   algoDBPath: `${__dirname}/../db/algos.json`,
   hfBitfinexDBPath: `${__dirname}/../db/hf-bitfinex.json`
+  // bfxRestURL: '',
+  // bfxWSURL: ''
 })

--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ module.exports = ({
   const as = new AlgoServer({
     port: algoServerPort,
     hfLowDBPath: algoDBPath,
-    apiDB
+    apiDB,
+    wsURL: bfxWSURL,
+    restURL: bfxRestURL
   })
 
   let dsBitfinex = null
@@ -66,10 +68,13 @@ module.exports = ({
     port: wsServerPort,
     exPoolURL: `http://localhost:${exPoolServerPort}`,
     algoServerURL: `http://localhost:${algoServerPort}`,
-    hfDSBitfinexURL: `http://localhost:${hfDSBitfinexPort}`
+    hfDSBitfinexURL: `http://localhost:${hfDSBitfinexPort}`,
+    restURL: bfxRestURL,
+    wsURL: bfxWSURL
   })
 
-  syncMarkets(apiDB, EXAS).then(() => {
+  const opts = { wsURL: bfxWSURL, restURL: bfxRestURL }
+  syncMarkets(apiDB, EXAS, opts).then(() => {
     as.open()
     exPool.open()
 

--- a/lib/ex_pool/add_client.js
+++ b/lib/ex_pool/add_client.js
@@ -10,8 +10,9 @@ const getAdapter = require('./get_adapter')
  * @param {string} exID - exchange ID
  * @return {boolean} success
  */
-module.exports = (pool, exID) => {
+module.exports = (pool, exID, opts) => {
   const { d, exchangeClients } = pool
+  const { wsURL, restURL } = opts
 
   if (!validExchange(exID)) {
     capture.exception('can\'t add unknown exchange: %s', exID)
@@ -19,7 +20,7 @@ module.exports = (pool, exID) => {
   }
 
   const EXA = getAdapter(exID)
-  const ex = new EXA()
+  const ex = new EXA({ wsURL, restURL })
 
   if (ex.openWS) {
     ex.openWS()

--- a/lib/ex_pool/subscribe.js
+++ b/lib/ex_pool/subscribe.js
@@ -7,9 +7,11 @@ const getSubscriptionRefCount = require('./get_sub_ref_count')
 const incrementSubscriptionRefCount = require('./increment_sub_ref_count')
 const chanDataToKey = require('../util/chan_data_to_key')
 
-module.exports = async ({ pool, exID, channel }) => {
+module.exports = async ({ pool, exID, channel, opts }) => {
+  const { wsURL, restURL } = opts
+
   if (!hasClient(pool, exID)) {
-    addClient(pool, exID)
+    addClient(pool, exID, { wsURL, restURL })
   }
 
   const ex = getClient(pool, exID)

--- a/lib/exchange_clients/bitfinex/index.js
+++ b/lib/exchange_clients/bitfinex/index.js
@@ -19,10 +19,13 @@ const unsubscribe = require('./unsubscribe')
 const subscribe = require('./subscribe')
 
 class BitfinexEchangeConnection {
-  constructor () {
+  constructor (opts) {
+    const { wsURL, restURL } = opts
+
+    this.wsURL = wsURL
     this.d = debug
     this.ws = null
-    this.rest = new RESTv2()
+    this.rest = new RESTv2({ url: restURL })
     this.channelMap = {}
     this.subs = {} // { [cdKey]: chanId }
     this.pendingSubs = {} //
@@ -54,12 +57,14 @@ class BitfinexEchangeConnection {
   }
 
   openWS (args = {}) {
-    this.ws = new WS2Manager({
+    const opts = {
+      url: this.wsURL,
       autoReconnect: true,
       reconnectDelay: 10 * 1000,
       ...args
-    }, this.authArgs)
+    }
 
+    this.ws = new WS2Manager(opts, this.authArgs)
     this.ws.on('message', (msg) => recvMessage(this, msg))
     this.ws.on('error', this.onWSError.bind(this))
     this.ws.on('auth', this.onWSAuth.bind(this))

--- a/lib/sync_meta.js
+++ b/lib/sync_meta.js
@@ -3,12 +3,12 @@
 const PI = require('p-iteration')
 const debug = require('debug')('bfx:hf:server:sync-meta')
 
-module.exports = async (db, exas) => {
+module.exports = async (db, exas, opts) => {
   const { Market } = db
 
   return PI.forEach(exas, async (EXA) => {
     const { id } = EXA
-    const exaClient = new EXA()
+    const exaClient = new EXA(opts)
 
     debug('fetching market list for exa %s', id)
     const markets = await exaClient.getMarkets()

--- a/lib/ws_servers/algos/ao_adapter.js
+++ b/lib/ws_servers/algos/ao_adapter.js
@@ -1,0 +1,262 @@
+'use strict'
+
+const Promise = require('bluebird')
+const _pick = require('lodash/pick')
+const _isEqual = require('lodash/isEqual')
+const _isObject = require('lodash/isObject')
+const _isString = require('lodash/isString')
+const _isEmpty = require('lodash/isEmpty')
+const { EventEmitter } = require('events')
+const debug = require('debug')('bfx:hf:ext-plugin:bitfinex:ao-adpater')
+const ManagedOB = require('bfx-api-node-plugin-managed-ob')
+const ManagedCandles = require('bfx-api-node-plugin-managed-candles')
+const Watchdog = require('bfx-api-node-plugin-wd')
+const { Order } = require('bfx-api-node-models')
+const {
+  subscribe, unsubscribe, findChannelId, Manager, cancelOrder, submitOrder,
+  send
+} = require('bfx-api-node-core')
+
+const HB_INTERVAL_MS = 2500
+
+module.exports = class AOAdapter extends EventEmitter {
+  static getTimeFrames () {
+    return {
+      '1 Minute': '1m',
+      '5 Minutes': '5m',
+      '15 Minutes': '15m',
+      '30 Minutes': '30m',
+      '1 Hour': '1h',
+      '3 Hours': '3h',
+      '6 Hours': '6h',
+      '12 Hours': '12h',
+      '1 Day': '1D',
+      '7 Days': '7D',
+      '14 Days': '14D',
+      '1 Month': '1M'
+    }
+  }
+
+  constructor ({
+    wsURL, restURL, apiKey, apiSecret, agent, dms, withHeartbeat, affiliateCode
+  }) {
+    super()
+
+    this.pendingOrderSubmitCancelTimeouts = []
+    this.affiliateCode = affiliateCode
+    this.hbEnabled = withHeartbeat
+    this.hbInterval = null
+    this.m = new Manager({
+      plugins: [ManagedOB(), ManagedCandles(), Watchdog({
+        packetWDDelay: 30 * 1000
+      })],
+
+      transform: true,
+      dms,
+      apiSecret,
+      apiKey,
+      agent,
+      wsURL,
+      restURL
+    })
+
+    this.m.on('ws2:error', this.propagateEvent.bind(this, 'meta:error'))
+    this.m.on('ws2:ticker', this.propagateDataEvent.bind(this, 'ticker'))
+    this.m.on('ws2:trades', this.propagateDataEvent.bind(this, 'trades'))
+    this.m.on('ws2:candles', this.propagateDataEvent.bind(this, 'candles'))
+    this.m.on('ws2:book', this.propagateDataEvent.bind(this, 'book'))
+    this.m.on('ws2:managed:book', this.propagateDataEvent.bind(this, 'managed:book'))
+    this.m.on('ws2:managed:candles', this.propagateDataEvent.bind(this, 'managed:candles'))
+    this.m.on('ws2:notification', this.propagateDataEvent.bind(this, 'notification'))
+
+    this.m.on('socket:updated', this.onSocketUpdate.bind(this))
+    this.m.on('ws2:event:info-server-restart', this.onServerRestart.bind(this))
+    this.m.on('ws2:reopen', this.onWSReopen.bind(this))
+
+    this.m.on('ws2:open', this.propagateEvent.bind(this, 'open'))
+    this.m.on('ws2:event:auth:success', this.propagateEvent.bind(this, 'auth:success'))
+    this.m.on('ws2:event:auth:error', this.propagateEvent.bind(this, 'auth:error'))
+    this.m.on('ws2:auth:n', this.propagateEvent.bind(this, 'auth:n'))
+    this.m.on('ws2:auth:os', this.propagateEvent.bind(this, 'order:snapshot'))
+    this.m.on('ws2:auth:on', this.propagateEvent.bind(this, 'order:new'))
+    this.m.on('ws2:auth:ou', this.propagateEvent.bind(this, 'order:update'))
+    this.m.on('ws2:auth:oc', this.propagateEvent.bind(this, 'order:close'))
+    this.m.on('ws2:data:trades', this.propagateEvent.bind(this, 'trades'))
+    this.m.on('ws2:data:book', this.propagateEvent.bind(this, 'book'))
+  }
+
+  updateAuthArgs (args = {}) {
+    this.m.updateAuthArgs(args)
+  }
+
+  reconnect () {
+    if (this.hbInterval !== null) {
+      clearInterval(this.hbInterval)
+      this.hbInterval = null
+    }
+
+    this.m.reconnectAllSockets()
+
+    if (this.hbEnabled) {
+      this.hbInterval = setInterval(this.sendHB.bind(this), HB_INTERVAL_MS)
+    }
+  }
+
+  connect () {
+    this.m.openWS()
+
+    if (this.hbEnabled) {
+      this.hbInterval = setInterval(this.sendHB.bind(this), HB_INTERVAL_MS)
+    }
+  }
+
+  /**
+    * @return {Promise} p
+    */
+  disconnect () {
+    if (this.hbInterval !== null) {
+      clearInterval(this.hbInterval)
+      this.hbInterval = null
+    }
+
+    // Clean up pending actions
+    this.pendingOrderSubmitCancelTimeouts.forEach(timeoutObject => {
+      if (timeoutObject.t !== null) {
+        clearTimeout(timeoutObject.t)
+        timeoutObject.t = null
+      }
+    })
+
+    this.pendingOrderSubmitCancelTimeouts = []
+
+    return this.m.closeAllSockets()
+  }
+
+  sendHB () {
+    this.m.withAuthSocket((ws) => {
+      send(ws, [0, 'n', null, {
+        mid: Date.now(),
+        type: 'ucm-hb',
+        info: {}
+      }])
+    })
+  }
+
+  getConnection () {
+    const id = this.m.sampleWSI()
+    const c = this.m.getWSByIndex(id)
+
+    return { id, c }
+  }
+
+  propagateEvent (name, ...args) {
+    this.emit(name, ...args)
+  }
+
+  propagateDataEvent (name, data, meta = {}) {
+    this.emit(`data:${name}`, data, meta)
+  }
+
+  onSocketUpdate (i, state) {
+    this.emit('meta:connection:update', i, state)
+  }
+
+  onServerRestart () {
+    // Otherwise the DMS flag closes all orders, and the packets are received
+    // after a server restart, before the connection drops. We cannot
+    // differentiate between manual user cancellations and those packets.
+    this._ignoreOrderEvents = true
+  }
+
+  onWSReopen () {
+    this._ignoreOrderEvents = false // see onServerRestart
+    this.emit('meta:reload')
+  }
+
+  subscribe (connection, channel, filter) {
+    subscribe(connection.c, channel, filter)
+  }
+
+  unsubscribe (connection, channel, filter) {
+    const cid = findChannelId(connection.c, (data) => {
+      if (data.channel !== channel) {
+        return false
+      }
+
+      const fv = _pick(data, Object.keys(filter))
+      return _isEqual(filter, fv)
+    })
+
+    if (!cid) {
+      return debug('error unsubscribing: unknown channel %s', channel)
+    }
+
+    unsubscribe(connection.c, cid)
+  }
+
+  orderEventsValid () {
+    return !this._ignoreOrderEvents
+  }
+
+  async submitOrderWithDelay (connection, delay, order) {
+    const { c } = connection
+
+    if (_isString(this.affiliateCode) && !_isEmpty(this.affiliateCode)) {
+      if (order instanceof Order) {
+        order.affiliateCode = this.affiliateCode
+      } else if (_isObject(order)) {
+        if (!order.meta) {
+          order.meta = {}
+        }
+
+        order.meta.aff_code = this.affiliateCode // eslint-disable-line
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => {
+        timeoutObject.t = null
+
+        submitOrder(c, order)
+          .then(resolve)
+          .catch(reject)
+      }, delay)
+
+      const timeoutObject = { t }
+      this.pendingOrderSubmitCancelTimeouts.push(timeoutObject)
+    })
+  }
+
+  async cancelOrderWithDelay (connection, delay, order) {
+    const { c } = connection
+
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => {
+        timeoutObject.t = null
+
+        cancelOrder(c, order)
+          .then(resolve)
+          .catch(reject)
+      }, delay)
+
+      const timeoutObject = { t }
+      this.pendingOrderSubmitCancelTimeouts.push(timeoutObject)
+    })
+  }
+
+  sendWithAnyConnection (packet) {
+    this.m.withAuthSocket((ws) => {
+      send(ws, packet)
+    })
+  }
+
+  notify (ws, level, message) {
+    send(ws, [0, 'n', null, {
+      type: 'ucm-notify-ui',
+      info: {
+        level,
+        message
+      }
+    }])
+  }
+}

--- a/lib/ws_servers/algos/index.js
+++ b/lib/ws_servers/algos/index.js
@@ -17,7 +17,9 @@ module.exports = class AlgoServer extends WSServer {
   constructor ({
     apiDB,
     port,
-    hfLowDBPath
+    hfLowDBPath,
+    wsURL,
+    restURL
   }) {
     super({
       port,
@@ -34,6 +36,8 @@ module.exports = class AlgoServer extends WSServer {
       }
     })
 
+    this.wsURL = wsURL
+    this.restURL = restURL
     this.apiDB = apiDB
     this.dbPath = hfLowDBPath
     this.clients = {}

--- a/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
+++ b/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
@@ -5,15 +5,15 @@ const HFDB = require('bfx-hf-models')
 const { RESTv2 } = require('bfx-api-node-rest')
 const HFDBLowDBAdapter = require('bfx-hf-models-adapter-lowdb')
 const {
-  AOAdapter: BFXAOAdapter,
   schema: HFDBBitfinexSchema
 } = require('bfx-hf-ext-plugin-bitfinex')
 
+const BFXAOAdapter = require('./ao_adapter')
 const initAOHost = require('../../util/init_ao_host')
 const BitfinexEXA = require('../../exchange_clients/bitfinex')
 
 module.exports = async (server, apiKey, apiSecret) => {
-  const { dbPath, apiDB, d } = server
+  const { dbPath, apiDB, d, wsURL, restURL } = server
   const { UserSettings } = apiDB
   const { userSettings: settings } = await UserSettings.getAll()
   const { dms, affiliateCode } = settings || DEFAULT_SETTINGS
@@ -30,7 +30,9 @@ module.exports = async (server, apiKey, apiSecret) => {
       apiSecret,
       dms: dms ? 4 : 0,
       withHeartbeat: true,
-      affiliateCode
+      affiliateCode,
+      wsURL,
+      restURL
     }),
 
     db: new HFDB({
@@ -44,7 +46,8 @@ module.exports = async (server, apiKey, apiSecret) => {
       const { aos } = aoHost
       const rest = new RESTv2({
         apiKey,
-        apiSecret
+        apiSecret,
+        url: restURL
       })
 
       await BitfinexEXA.registerUIDefs(aos, rest)

--- a/lib/ws_servers/api/handlers/on_auth_init.js
+++ b/lib/ws_servers/api/handlers/on_auth_init.js
@@ -18,7 +18,7 @@ module.exports = async (server, ws, msg) => {
     return notifyError(ws, 'Already authenticated')
   }
 
-  const { d, db } = server
+  const { d, db, wsURL, restURL } = server
   const [, password] = msg
   const validRequest = validateParams(ws, {
     password: { type: 'string', v: password }
@@ -62,6 +62,6 @@ module.exports = async (server, ws, msg) => {
   ws.aoc = server.openAlgoServerClient()
   ws.aoc.identify(ws, cipherControl)
 
-  await sendAuthenticated(ws, db, d)
+  await sendAuthenticated(ws, db, d, { wsURL, restURL })
   await sendStrategies(ws, db, d)
 }

--- a/lib/ws_servers/api/handlers/on_auth_submit.js
+++ b/lib/ws_servers/api/handlers/on_auth_submit.js
@@ -14,7 +14,7 @@ module.exports = async (server, ws, msg) => {
     return notifyError(ws, 'Already authenticated')
   }
 
-  const { d, db } = server
+  const { d, db, wsURL, restURL } = server
   const [, password] = msg
   const validRequest = validateParams(ws, {
     password: { type: 'string', v: password }
@@ -46,6 +46,6 @@ module.exports = async (server, ws, msg) => {
   ws.aoc = server.openAlgoServerClient()
   ws.aoc.identify(ws, authControl)
 
-  await sendAuthenticated(ws, db, d)
+  await sendAuthenticated(ws, db, d, { wsURL, restURL })
   await sendStrategies(ws, db, d)
 }

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -16,7 +16,7 @@ const capture = require('../../../capture')
 const openAuthBitfinexConnection = require('../open_auth_bitfinex_connection')
 
 module.exports = async (server, ws, msg) => {
-  const { d, db } = server
+  const { d, db, wsURL, restURL } = server
   const [, authToken, exID, apiKey, apiSecret] = msg
   const validRequest = validateParams(ws, {
     exID: { type: 'string', v: exID },
@@ -90,8 +90,9 @@ module.exports = async (server, ws, msg) => {
 
   switch (exID) {
     case 'bitfinex': {
+      const opts = { wsURL, restURL }
       ws.aoc.openHost('bitfinex', apiKey, apiSecret)
-      ws.clients.bitfinex = await openAuthBitfinexConnection(ws, apiKey, apiSecret, db, d)
+      ws.clients.bitfinex = await openAuthBitfinexConnection({ ws, apiKey, apiSecret, db, d, opts })
       break
     }
 

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -38,7 +38,9 @@ module.exports = class APIWSServer extends WSServer {
     db,
     hfDSBitfinexURL,
     exPoolURL,
-    algoServerURL
+    algoServerURL,
+    restURL,
+    wsURL
   }) {
     super({
       port,
@@ -73,6 +75,9 @@ module.exports = class APIWSServer extends WSServer {
     this.hfDSClients = {
       bitfinex: new HFDSClient({ id: 'bitfinex', url: hfDSBitfinexURL })
     }
+
+    this.wsURL = wsURL
+    this.restURL = restURL
   }
 
   openAlgoServerClient () {

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -8,12 +8,15 @@ const BitfinexExchangeConnection = require('../../exchange_clients/bitfinex')
 const { notifyInfo, notifyError, notifySuccess } = require('../../util/ws/notify')
 const send = require('../../util/ws/send')
 
-module.exports = async (ws, apiKey, apiSecret, db, d) => {
+module.exports = async (conf) => {
+  const { ws, apiKey, apiSecret, db, d, opts } = conf
+
   notifyInfo(ws, 'Connecting to Bitfinex...')
 
+  const { wsURL, restURL } = opts
   const { UserSettings } = db
   const { userSettings: settings } = await UserSettings.getAll()
-  const client = new BitfinexExchangeConnection()
+  const client = new BitfinexExchangeConnection({ wsURL, restURL })
   const { dms } = settings || DEFAULT_SETTINGS
 
   d('opening auth bfx connection (dms %s)', dms ? 'enabled' : 'disabled')

--- a/lib/ws_servers/api/send_authenticated.js
+++ b/lib/ws_servers/api/send_authenticated.js
@@ -8,7 +8,7 @@ const decryptAPICredentials = require('../../util/decrypt_api_credentials')
 const { CREDENTIALS_CID } = require('../../db/credentials')
 const openAuthBitfinexConnection = require('./open_auth_bitfinex_connection')
 
-module.exports = async (ws, db, d) => {
+module.exports = async (ws, db, d, opts) => {
   const { authPassword, authControl } = ws
 
   if (!authPassword || !authControl) {
@@ -49,7 +49,7 @@ module.exports = async (ws, db, d) => {
     switch (exID) {
       case 'bitfinex': {
         ws.aoc.openHost('bitfinex', key, secret)
-        ws.clients.bitfinex = await openAuthBitfinexConnection(ws, key, secret, db, d)
+        ws.clients.bitfinex = await openAuthBitfinexConnection({ ws, apiKey: key, apiSecret: secret, db, d, opts })
         break
       }
 

--- a/lib/ws_servers/api/submit_order_bitfinex.js
+++ b/lib/ws_servers/api/submit_order_bitfinex.js
@@ -13,7 +13,7 @@ module.exports = async (d, ws, bfxClient, orderPacket) => {
 
     d('sucessfully submitted order [bitfinex]')
   } catch (error) {
-    d('failed to submit order [bitfinex]')
+    d('failed to submit order [bitfinex]', error)
     notifyErrorBitfinex(ws, error)
   }
 }

--- a/lib/ws_servers/ex_pool/on_subscribe.js
+++ b/lib/ws_servers/ex_pool/on_subscribe.js
@@ -5,13 +5,14 @@ const sendError = require('../../util/ws/send_error')
 const poolSubscribe = require('../../ex_pool/subscribe')
 
 module.exports = async (server, ws, msg) => {
-  const { pool, d } = server
+  const { pool, d, wsURL, restURL } = server
   const [, exID, channel] = msg
 
   let chanID
 
   try {
-    chanID = await poolSubscribe({ pool, exID, channel })
+    const opts = { wsURL, restURL }
+    chanID = await poolSubscribe({ pool, exID, channel, opts })
   } catch (err) {
     d('error subscribing to %s %j: %s', exID, channel, err.stack)
     return sendError(ws, 'Internal error subscribing')


### PR DESCRIPTION
this pr brings in the exchange adapter for our only exchange
bitfinex, and fixes places where urls to the apis where not
dynamic, but relied on defaults in the abstractions.

the `lib/ws_servers/algos/ao_adapter.js` file is coming from
`bfx-hf-ext-plugin-bitfinex`.

with that PR, devs can run algo orders easily on staging, without
changing it in the submodules, i.e. the
`bfx-hf-ext-plugin-bitfinex` adapter

with just one exchange the exchange pool is superfluous, and will
get removed in next refactors.

the next step for simplifying the repos is to simplify algo orders,
e.g. removing one of the current two used algo servers (one inside
repo, one via a submodule called `bfx-hf-algo-server`)