### PR TITLE
remove ui defs for bfx main ui

### DIFF
--- a/lib/exchange_clients/bitfinex/index.js
+++ b/lib/exchange_clients/bitfinex/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const _isFunction = require('lodash/isFunction')
 const { WS2Manager } = require('bitfinex-api-node')
 const { RESTv2 } = require('bfx-api-node-rest')
 const debug = require('debug')('bfx:hf:server:exchange-clients:bitfinex')
@@ -163,45 +162,6 @@ class BitfinexEchangeConnection {
 
   static transformOrders (orders) {
     return orders.map(orderTransformer)
-  }
-
-  static async registerUIDefs (algoOrders, rest) {
-    const timeframes = BitfinexEchangeConnection.getCandleTimeFrames()
-    const aoUIDefs = algoOrders.filter((ao) => {
-      const { meta = {} } = ao
-      const { getUIDef } = meta
-
-      return _isFunction(getUIDef)
-    }).map((ao) => {
-      const { meta = {} } = ao
-      const { getUIDef } = meta
-      const { id } = ao
-
-      return {
-        id,
-        uiDef: getUIDef({ timeframes })
-      }
-    })
-
-    const AO_SETTINGS_KEY = 'api:bitfinex_algorithmic_orders'
-
-    debug(
-      'overwriting algo order UI definition user settings (key %s)',
-      AO_SETTINGS_KEY
-    )
-
-    const res = await rest.getSettings([AO_SETTINGS_KEY])
-    const [keyResult = []] = res
-    const [, aoSettings = {}] = keyResult
-
-    aoUIDefs.forEach(({ id, uiDef }) => {
-      debug('setting UI def for %s', id)
-      aoSettings[id] = uiDef
-    })
-
-    await rest.updateSettings({ [AO_SETTINGS_KEY]: aoSettings })
-
-    debug('all UIs registered!')
   }
 }
 

--- a/lib/ws_servers/algos/init_ao_host.js
+++ b/lib/ws_servers/algos/init_ao_host.js
@@ -2,7 +2,6 @@
 
 const _isFunction = require('lodash/isFunction')
 const { AOHost } = require('bfx-hf-algo')
-const AOServer = require('bfx-hf-algo-server')
 
 const {
   PingPong, Iceberg, TWAP, AccumulateDistribute, MACrossover, OCOCO
@@ -17,14 +16,6 @@ module.exports = async ({ adapter, db, initCB }) => {
     db,
     adapter,
     aos: algoOrders
-  })
-
-  // For communication with the official BFX UI
-  new AOServer({ // eslint-disable-line no-new
-    db,
-    adapter,
-    aos: algoOrders,
-    host
   })
 
   if (_isFunction(initCB)) {

--- a/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
+++ b/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
@@ -2,7 +2,6 @@
 
 const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
 const HFDB = require('bfx-hf-models')
-const { RESTv2 } = require('bfx-api-node-rest')
 const HFDBLowDBAdapter = require('bfx-hf-models-adapter-lowdb')
 const {
   schema: HFDBBitfinexSchema
@@ -10,7 +9,6 @@ const {
 
 const BFXAOAdapter = require('./ao_adapter')
 const initAOHost = require('./init_ao_host')
-const BitfinexEXA = require('../../exchange_clients/bitfinex')
 
 module.exports = async (server, apiKey, apiSecret) => {
   const { dbPath, apiDB, d, wsURL, restURL } = server
@@ -42,15 +40,6 @@ module.exports = async (server, apiKey, apiSecret) => {
       })
     }),
 
-    initCB: async (aoHost) => {
-      const { aos } = aoHost
-      const rest = new RESTv2({
-        apiKey,
-        apiSecret,
-        url: restURL
-      })
-
-      await BitfinexEXA.registerUIDefs(aos, rest)
-    }
+    initCB: async (aoHost) => {}
   })
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bfx-api-node-rest": "^1.1.4",
     "bfx-api-node-util": "^1.0.9",
     "bfx-hf-algo": "^2.0.1",
-    "bfx-hf-algo-server": "^1.4.1",
     "bfx-hf-data-server": "^1.3.0",
     "bfx-hf-ext-plugin-bitfinex": "^1.0.0",
     "bfx-hf-ext-plugin-dummy": "^1.0.0",


### PR DESCRIPTION
this removes the algo-server module from the source code which was uploading ui definitions / settings for the user to make them available in the bitfinex main ui. it created a lot of additional complexity and is running an additional, seperate websocket server next to the 4 we are already using internally, and its a feature not widely used, so we remove it to be able to focus on other features.

**screenshot from bitfinex main ui**
![Screen Shot 2020-10-27 at 15 16 17](https://user-images.githubusercontent.com/298166/97316098-aabbd000-1869-11eb-878a-8ddd0c19b287.png)

