### PR TITLE
clear stored favorite pairs

### DIFF
--- a/lib/ws_servers/api/handlers/on_auth_reset.js
+++ b/lib/ws_servers/api/handlers/on_auth_reset.js
@@ -5,11 +5,12 @@ const { notifyInfo } = require('../../../util/ws/notify')
 
 module.exports = async (server, ws, msg) => {
   const { d, db } = server
-  const { Credential, Strategy, UserSettings } = db
+  const { Credential, Strategy, UserSettings, FavouriteTradingPairs } = db
 
   await Credential.rmAll()
   await Strategy.rmAll()
   await UserSettings.rmAll()
+  await FavouriteTradingPairs.rmAll()
 
   send(ws, ['info.auth_configured', false])
   send(ws, ['info.auth_token', null])


### PR DESCRIPTION
After pressing the "Clear data & reset" button the UI sends auth.reset message through the ws to the bfx-hf-server. So it should be appropriately processed which means that we need to add a step of removing stored favorite trading pairs.