### PR TITLE
unsub: don't crash server when unsub fails

### DIFF
--- a/lib/exchange_clients/bitfinex/unsubscribe.js
+++ b/lib/exchange_clients/bitfinex/unsubscribe.js
@@ -4,13 +4,14 @@ const chanDataToKey = require('../../util/chan_data_to_key')
 const chanDataToSubscribePacket = require('./util/chan_data_to_subscribe_packet')
 
 module.exports = (exa, channelData) => {
-  const { d, ws, subs, channelMap } = exa
+  const { d, ws, subs, channelMap, pendingSubs } = exa
 
   const cdKey = chanDataToKey(channelData)
   const chanID = subs[cdKey]
 
   if (!chanID) {
-    throw new Error('tried to unsub from unknown channel')
+    d('tried to unsub from unknown channel', chanID)
+    return
   }
 
   d('unsubscribing from channel %s', chanID)
@@ -45,6 +46,7 @@ module.exports = (exa, channelData) => {
 
   delete subs[cdKey]
   delete channelMap[`${chanID}`]
+  delete pendingSubs[cdKey]
 
   return chanID
 }

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -82,7 +82,6 @@ module.exports = class APIWSServer extends WSServer {
     this.restURL = restURL
 
     this.exchangeClient = new EXCHANGE_ADAPTERS[0]({})
-    this.exchangeClient.openWS()
   }
 
   openAlgoServerClient () {
@@ -109,6 +108,8 @@ module.exports = class APIWSServer extends WSServer {
 
   async onWSSConnection (ws) {
     super.onWSSConnection(ws)
+
+    this.exchangeClient.openWS()
 
     ws.clients = {}
     ws.user = null
@@ -142,6 +143,8 @@ module.exports = class APIWSServer extends WSServer {
         this.exchangeClient.unsubscribe(channelData)
       })
     })
+
+    this.exchangeClient.close()
 
     ws.clients = {}
     ws.user = null


### PR DESCRIPTION
when the client was reloaded right during the login, sometimes a
pending subscription was still pending. this couldn't be found
later any more, leading to a crash of the server.

the issue is fixed by several improvements:

1. don't crash the whole server in case a simple unsubscribe fails
2. `pendingSubscriptions` was leaking, it was not cleared after a
   subscription was cancelled. now the object entry is removed on
   an unsub
3. the exchange client is reset for each new connection, so we
   start with a blank slate for a new connection