### PR TITLE
Algo order resume permission

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -1,13 +1,17 @@
 'use strict'
 
+const os = require('os')
+
 process.env.DEBUG = 'bfx:hf:*'
 
 const startHFServer = require('..')
 
+const dir = `${os.homedir()}/.honeyframework`
+
 startHFServer({
-  uiDBPath: `${__dirname}/../db/ui.json`,
-  algoDBPath: `${__dirname}/../db/algos.json`,
-  hfBitfinexDBPath: `${__dirname}/../db/hf-bitfinex.json`
+  uiDBPath: `${dir}/ui.json`,
+  algoDBPath: `${dir}/algos.json`
+
   // bfxRestURL: '',
   // bfxWSURL: ''
 })

--- a/lib/exchange_clients/bitfinex/subscribe.js
+++ b/lib/exchange_clients/bitfinex/subscribe.js
@@ -47,7 +47,9 @@ module.exports = async (exa, channelData) => {
       break
     }
 
-    default: {}
+    default: {
+      break
+    }
   }
 
   return p

--- a/lib/util/ksort.js
+++ b/lib/util/ksort.js
@@ -4,7 +4,7 @@ module.exports = (obj) => {
   const keys = Object.keys(obj).sort()
   const sortedObj = {}
 
-  for (var i in keys) {
+  for (const i in keys) {
     sortedObj[keys[i]] = obj[keys[i]]
   }
 

--- a/lib/ws_clients/algos/handlers/on_loaded_ao.js
+++ b/lib/ws_clients/algos/handlers/on_loaded_ao.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const send = require('../../../util/ws/send')
+
+module.exports = (client, msg) => {
+  const { userWS, d } = client
+  const [,, gid] = msg
+
+  d('ao instance loaded %s', gid)
+  send(userWS, ['algo.order_loaded', gid])
+}

--- a/lib/ws_clients/algos/handlers/on_reloaded_ao.js
+++ b/lib/ws_clients/algos/handlers/on_reloaded_ao.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const send = require('../../../util/ws/send')
+
+module.exports = (client, msg) => {
+  const { userWS } = client
+
+  send(userWS, ['algo.cancel_orders'])
+}

--- a/lib/ws_clients/algos/index.js
+++ b/lib/ws_clients/algos/index.js
@@ -6,12 +6,14 @@ const WSClient = require('../../ws_client')
 
 const onUnknownMessage = require('./handlers/on_unknown_message')
 const onError = require('./handlers/on_error')
+const onLoadedAO = require('./handlers/on_loaded_ao')
 const onStartedAO = require('./handlers/on_started_ao')
 const onStoppedAO = require('./handlers/on_stopped_ao')
 const onRefusingHostClose = require('./handlers/on_refusing_host_close')
 const onHostClosed = require('./handlers/on_host_closed')
 const onHostOpened = require('./handlers/on_host_opened')
 const onIdentified = require('./handlers/on_identified')
+const onReloadedAO = require('./handlers/on_reloaded_ao')
 const onStatus = require('./handlers/on_status')
 const onDataAOs = require('./handlers/on_data_aos')
 const onIsOpenResponse = require('./handlers/on_is_open_res')
@@ -28,6 +30,8 @@ module.exports = class AlgosServerClient extends WSClient {
         _: onUnknownMessage,
 
         error: onError,
+        loaded: onLoadedAO,
+        reloaded: onReloadedAO,
         started: onStartedAO,
         stopped: onStoppedAO,
         persisting: onRefusingHostClose,
@@ -94,5 +98,12 @@ module.exports = class AlgosServerClient extends WSClient {
     }
 
     this.send(['cancel', this.userID, exID, gid])
+  }
+
+  loadAOs (orders) {
+    if (!this.userID) {
+      return this.d('refusing to load host bitfinex, not identified')
+    }
+    this.send(['load', this.userID, 'bitfinex', orders])
   }
 }

--- a/lib/ws_servers/algos/handlers/on_load.js
+++ b/lib/ws_servers/algos/handlers/on_load.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const sendError = require('../../../util/ws/send_error')
+const validateParams = require('../../../util/ws/validate_params')
+
+const getHostKey = require('../util/get_host_key')
+
+module.exports = async (server, ws, msg) => {
+  const { d, hosts, algoDB } = server
+  const { AlgoOrder } = algoDB
+  const [, userID, exID, orders] = msg
+
+  const validRequest = validateParams(ws, {
+    userID: { type: 'string', v: userID },
+    orders: { type: 'array', v: orders }
+  })
+
+  if (!validRequest) {
+    return d('invalid request: algos:handlers:on_load')
+  } else if (!ws.userID) {
+    return sendError(ws, 'Not identified')
+  } else if (ws.userID !== userID) {
+    d('tried to load AO for user that differs from ws ident (%s)', userID)
+    return sendError(ws, 'Unauthorised')
+  }
+
+  const key = getHostKey(userID, exID)
+  const host = hosts[key]
+
+  if (!host) {
+    return sendError(ws, `Host not open for user ${userID} on exchange ${exID}`)
+  }
+
+  for (const algOrder of orders) {
+    const { algoID, gid } = algOrder
+    try {
+      const ao = await AlgoOrder.get({ algoID, gid })
+      let { state, active } = ao || {}
+      if (!state || !active) {
+        continue
+      }
+      state = JSON.parse(state)
+      state.active = true
+      await host.loadAO(algoID, gid, state)
+      d('AO loaded for user %s on exchange %s [%s]', userID, exID, gid)
+    } catch (e) {
+      d('error loading AO %s for %s: %s', algoID, exID, e.stack)
+      sendError(ws, `Failed to start algo order: ${algoID}`)
+    }
+  }
+}

--- a/lib/ws_servers/algos/handlers/on_open.js
+++ b/lib/ws_servers/algos/handlers/on_open.js
@@ -9,7 +9,8 @@ const getHostKey = require('../util/get_host_key')
 const spawnBitfinexAOHost = require('../spawn_bitfinex_ao_host')
 
 module.exports = async (server, ws, msg) => {
-  const { d, hosts } = server
+  const { d, hosts, algoDB } = server
+
   const [, userID, exID, apiKey, apiSecret] = msg
   const validRequest = validateParams(ws, {
     exID: { type: 'string', v: exID },
@@ -62,12 +63,28 @@ module.exports = async (server, ws, msg) => {
     server.broadcast(userID, ['started', userID, exID, name, label, gid, args])
   })
 
+  hosts[key].on('ao:loaded', (gid) => {
+    d('ao loaded: %s', gid)
+    server.broadcast(userID, ['loaded', userID, gid])
+  })
+
+  hosts[key].on('meta:reload', async () => {
+    d('meta reloaded')
+    server.broadcast(userID, ['reloaded', userID])
+  })
+
   hosts[key].on('ao:stop', (instance) => {
     const { state = {} } = instance
     const { gid } = state
 
     d('ao stopped: %s', gid)
     server.broadcast(userID, ['stopped', userID, exID, gid])
+  })
+
+  hosts[key].on('ao:persist:db:update', async (updateOpts) => {
+    const { AlgoOrder } = algoDB
+    await AlgoOrder.set(updateOpts)
+    d('ao instance updated %s', updateOpts.gid)
   })
 
   send(ws, ['opened', userID, exID])

--- a/lib/ws_servers/algos/index.js
+++ b/lib/ws_servers/algos/index.js
@@ -5,6 +5,7 @@ const WSServer = require('../../ws_server')
 const send = require('../../util/ws/send')
 const onIdentify = require('./handlers/on_identify')
 const onSubmit = require('./handlers/on_submit')
+const onLoad = require('./handlers/on_load')
 const onCancel = require('./handlers/on_cancel')
 const onOpen = require('./handlers/on_open')
 const onClose = require('./handlers/on_close')
@@ -15,9 +16,9 @@ const parseHostKey = require('./util/parse_host_key')
 
 module.exports = class AlgoServer extends WSServer {
   constructor ({
+    algoDB,
     apiDB,
     port,
-    hfLowDBPath,
     wsURL,
     restURL
   }) {
@@ -28,6 +29,7 @@ module.exports = class AlgoServer extends WSServer {
         identify: onIdentify,
         reconnect: onReconnect,
         submit: onSubmit,
+        load: onLoad,
         cancel: onCancel,
         open: onOpen,
         close: onClose,
@@ -39,7 +41,7 @@ module.exports = class AlgoServer extends WSServer {
     this.wsURL = wsURL
     this.restURL = restURL
     this.apiDB = apiDB
-    this.dbPath = hfLowDBPath
+    this.algoDB = algoDB
     this.clients = {}
     this.hosts = {}
   }

--- a/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
+++ b/lib/ws_servers/algos/spawn_bitfinex_ao_host.js
@@ -1,11 +1,6 @@
 'use strict'
 
 const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
-const HFDB = require('bfx-hf-models')
-const HFDBLowDBAdapter = require('bfx-hf-models-adapter-lowdb')
-const {
-  schema: HFDBBitfinexSchema
-} = require('bfx-hf-ext-plugin-bitfinex')
 
 const { AOHost } = require('bfx-hf-algo')
 const {
@@ -17,7 +12,7 @@ const algoOrders = [
 ]
 
 module.exports = async (server, apiKey, apiSecret) => {
-  const { dbPath, apiDB, d, wsURL, restURL } = server
+  const { apiDB, d, wsURL, restURL } = server
   const { UserSettings } = apiDB
   const { userSettings: settings } = await UserSettings.getAll()
   const { dms, affiliateCode } = settings || DEFAULT_SETTINGS
@@ -39,12 +34,6 @@ module.exports = async (server, apiKey, apiSecret) => {
   }
 
   const host = new AOHost({
-    db: new HFDB({
-      schema: HFDBBitfinexSchema,
-      adapter: HFDBLowDBAdapter({
-        dbPath
-      })
-    }),
     aos: algoOrders,
     wsSettings
   })

--- a/lib/ws_servers/api/handlers/on_active_algo_orders_request.js
+++ b/lib/ws_servers/api/handlers/on_active_algo_orders_request.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const sendError = require('../../../util/ws/send_error')
+const send = require('../../../util/ws/send')
+const validateParams = require('../../../util/ws/validate_params')
+const isAuthorized = require('../../../util/ws/is_authorized')
+
+module.exports = async (server, ws, msg) => {
+  const { d, algoDB } = server
+  const { AlgoOrder } = algoDB
+
+  const [, authToken] = msg
+
+  const validRequest = validateParams(ws, {
+    authToken: { type: 'string', v: authToken }
+  })
+
+  if (!validRequest) {
+    d('invalid request: active_algo_orders_request')
+    return
+  }
+
+  if (!isAuthorized(ws, authToken)) {
+    return sendError(ws, 'Unauthorized')
+  } else if (!ws.aoc) {
+    return sendError(ws, 'Unauthorized')
+  }
+
+  const aos = await AlgoOrder.find([['active', '=', true]])
+
+  send(ws, [
+    'algo.active_orders',
+    aos.map(({ gid, state }) => {
+      const { args, label, name } = JSON.parse(state)
+      return { args, gid, label, name }
+    })
+  ])
+}

--- a/lib/ws_servers/api/handlers/on_algo_order_load.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_load.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const sendError = require('../../../util/ws/send_error')
+const validateParams = require('../../../util/ws/validate_params')
+const isAuthorized = require('../../../util/ws/is_authorized')
+
+module.exports = async (server, ws, msg) => {
+  const { d } = server
+  const [, authToken, orders] = msg
+
+  const validRequest = validateParams(ws, {
+    authToken: { type: 'string', v: authToken },
+    orders: { type: 'array', v: orders }
+  })
+
+  if (!validRequest) {
+    d('invalid request: algo:load')
+    return
+  }
+
+  if (!isAuthorized(ws, authToken)) {
+    return sendError(ws, 'Unauthorized')
+  } else if (!ws.aoc) {
+    return sendError(ws, 'Unauthorized')
+  }
+
+  ws.aoc.loadAOs(orders)
+}

--- a/lib/ws_servers/api/handlers/on_algo_order_remove.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_remove.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const sendError = require('../../../util/ws/send_error')
+const validateParams = require('../../../util/ws/validate_params')
+const isAuthorized = require('../../../util/ws/is_authorized')
+
+module.exports = async (server, ws, msg) => {
+  const { algoDB, as } = server
+
+  const [, authToken, exID, orders] = msg
+
+  const validRequest = validateParams(ws, {
+    exID: { type: 'string', v: exID },
+    authToken: { type: 'string', v: authToken },
+    orders: { type: 'array', v: orders }
+  })
+
+  if (!validRequest) {
+    return
+  }
+
+  if (!isAuthorized(ws, authToken)) {
+    return sendError(ws, 'Unauthorized')
+  } else if (exID !== 'bitfinex') {
+    return sendError(ws, 'Algo orders currently only enabled for Bitfinex')
+  } else if (!ws.aoc) {
+    return sendError(ws, 'Unauthorized')
+  }
+
+  for (const algOrder of orders) {
+    const { gid, algoID } = algOrder
+    const { AlgoOrder } = algoDB
+    await AlgoOrder.update({ gid, algoID }, { active: false })
+  }
+
+  as.open()
+}

--- a/lib/ws_servers/api/handlers/on_algo_order_remove.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_remove.js
@@ -1,37 +1,46 @@
 'use strict'
 
 const sendError = require('../../../util/ws/send_error')
+const send = require('../../../util/ws/send')
 const validateParams = require('../../../util/ws/validate_params')
 const isAuthorized = require('../../../util/ws/is_authorized')
 
 module.exports = async (server, ws, msg) => {
-  const { algoDB, as } = server
+  const { d, algoDB } = server
+  const { AlgoOrder } = algoDB
 
-  const [, authToken, exID, orders] = msg
+  const [, authToken, orders] = msg
 
   const validRequest = validateParams(ws, {
-    exID: { type: 'string', v: exID },
     authToken: { type: 'string', v: authToken },
     orders: { type: 'array', v: orders }
   })
 
   if (!validRequest) {
+    d('invalid request: algo:remove')
     return
   }
 
   if (!isAuthorized(ws, authToken)) {
     return sendError(ws, 'Unauthorized')
-  } else if (exID !== 'bitfinex') {
-    return sendError(ws, 'Algo orders currently only enabled for Bitfinex')
   } else if (!ws.aoc) {
     return sendError(ws, 'Unauthorized')
   }
 
+  const removedOrders = []
+
   for (const algOrder of orders) {
     const { gid, algoID } = algOrder
-    const { AlgoOrder } = algoDB
-    await AlgoOrder.update({ gid, algoID }, { active: false })
+    try {
+      const updated = await AlgoOrder.update({ gid, algoID }, { active: false })
+      if (updated) removedOrders.push(gid)
+    } catch (err) {
+      sendError(ws, `Error removing order: ${algoID} [${gid}]`)
+      d('error removing order %s [%s]: %s', gid, algoID, err.stack)
+    }
   }
 
-  as.open()
+  send(ws, ['algo.orders_removed', removedOrders])
+
+  d('removed selected orders %s', JSON.stringify(removedOrders))
 }

--- a/lib/ws_servers/api/handlers/on_save_favourite_trading_pairs.js
+++ b/lib/ws_servers/api/handlers/on_save_favourite_trading_pairs.js
@@ -18,7 +18,7 @@ module.exports = async (server, ws, msg) => {
   })
 
   if (!validRequest) {
-    d(`error: Invalid request params while saving favourite trading pairs`)
+    d('error: Invalid request params while saving favourite trading pairs')
     return
   }
 

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const PI = require('p-iteration')
-
+const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
 const { get: getCredentials } = require('../../db/credentials')
 const EXCHANGE_ADAPTERS = require('../../exchange_clients')
 const send = require('../../util/ws/send')
 const HFDSClient = require('../../ws_clients/hf_ds')
 const AlgoServerClient = require('../../ws_clients/algos')
+const AlgoServer = require('../../ws_servers/algos')
 const WSServer = require('../../ws_server')
 
 const onAuthSubmit = require('./handlers/on_auth_submit')
@@ -21,6 +22,7 @@ const onBacktestServerSideExecute = require('./handlers/on_backtest_execute_serv
 const onSaveStrategy = require('./handlers/on_save_strategy')
 const onRemoveStrategy = require('./handlers/on_remove_strategy')
 const onSaveAPICredentials = require('./handlers/on_save_api_credentials')
+const onAlgoOrderRemove = require('./handlers/on_algo_order_remove')
 const onOrderSubmit = require('./handlers/on_order_submit')
 const onOrderCancel = require('./handlers/on_order_cancel')
 const onAlgoOrderSubmit = require('./handlers/on_algo_order_submit')
@@ -37,6 +39,8 @@ module.exports = class APIWSServer extends WSServer {
     port,
     server,
     db,
+    algoDB,
+    algoServerParams,
     hfDSBitfinexURL,
     algoServerURL,
     restURL,
@@ -65,6 +69,7 @@ module.exports = class APIWSServer extends WSServer {
         'api_credentials.save': onSaveAPICredentials,
         'order.submit': onOrderSubmit,
         'order.cancel': onOrderCancel,
+        'algo_order.remove': onAlgoOrderRemove,
         'algo_order.submit': onAlgoOrderSubmit,
         'algo_order.cancel': onAlgoOrderCancel,
         'settings.update': onSettingsUpdate,
@@ -73,6 +78,7 @@ module.exports = class APIWSServer extends WSServer {
     })
 
     this.db = db
+    this.algoDB = algoDB
     this.algoServerURL = algoServerURL
     this.hfDSClients = {
       bitfinex: new HFDSClient({ id: 'bitfinex', url: hfDSBitfinexURL })
@@ -82,6 +88,7 @@ module.exports = class APIWSServer extends WSServer {
     this.restURL = restURL
 
     this.exchangeClient = new EXCHANGE_ADAPTERS[0]({})
+    this.as = new AlgoServer(algoServerParams)
   }
 
   openAlgoServerClient () {
@@ -106,6 +113,33 @@ module.exports = class APIWSServer extends WSServer {
     send(ws, ['info.auth_configured', !!credentials])
   }
 
+  async sendActiveAlgoOrders (ws) {
+    const { UserSettings } = this.db
+    const { AlgoOrder } = this.algoDB
+    const { userSettings: settings } = await UserSettings.getAll()
+    const { dms } = settings || DEFAULT_SETTINGS
+
+    if (dms) {
+      this.as.open()
+      return
+    }
+
+    const aos = await AlgoOrder.find([['active', '=', true]])
+
+    if (aos.length === 0) {
+      this.as.open()
+    } else {
+      send(ws, [
+        'info.active_algos',
+        aos.map(({ gid, algoID, state }) => {
+          state = JSON.parse(state)
+          delete state.args
+          return { gid, algoID, state }
+        })
+      ])
+    }
+  }
+
   async onWSSConnection (ws) {
     super.onWSSConnection(ws)
 
@@ -115,6 +149,8 @@ module.exports = class APIWSServer extends WSServer {
     ws.user = null
 
     await this.sendInitialConnectionData(ws)
+
+    await this.sendActiveAlgoOrders(ws)
 
     this.exchangeClient.onData((chanID, data) => {
       send(ws, ['data', 'bitfinex', chanID, data])

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const PI = require('p-iteration')
-const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
 const { get: getCredentials } = require('../../db/credentials')
 const EXCHANGE_ADAPTERS = require('../../exchange_clients')
 const send = require('../../util/ws/send')
 const HFDSClient = require('../../ws_clients/hf_ds')
 const AlgoServerClient = require('../../ws_clients/algos')
-const AlgoServer = require('../../ws_servers/algos')
 const WSServer = require('../../ws_server')
 
 const onAuthSubmit = require('./handlers/on_auth_submit')
@@ -16,6 +14,7 @@ const onAuthReset = require('./handlers/on_auth_reset')
 const onSubscribe = require('./handlers/on_subscribe')
 const onUnsubscribe = require('./handlers/on_unsubscribe')
 const onCandleRequest = require('./handlers/on_candle_request')
+const onActiveAlgoOrdersRequest = require('./handlers/on_active_algo_orders_request')
 const onBacktestExecute = require('./handlers/on_backtest_execute')
 const onBacktestServerSideExecute = require('./handlers/on_backtest_execute_serverside')
 
@@ -23,6 +22,7 @@ const onSaveStrategy = require('./handlers/on_save_strategy')
 const onRemoveStrategy = require('./handlers/on_remove_strategy')
 const onSaveAPICredentials = require('./handlers/on_save_api_credentials')
 const onAlgoOrderRemove = require('./handlers/on_algo_order_remove')
+const onAlgoOrderLoad = require('./handlers/on_algo_order_load')
 const onOrderSubmit = require('./handlers/on_order_submit')
 const onOrderCancel = require('./handlers/on_order_cancel')
 const onAlgoOrderSubmit = require('./handlers/on_algo_order_submit')
@@ -40,7 +40,6 @@ module.exports = class APIWSServer extends WSServer {
     server,
     db,
     algoDB,
-    algoServerParams,
     hfDSBitfinexURL,
     algoServerURL,
     restURL,
@@ -60,6 +59,7 @@ module.exports = class APIWSServer extends WSServer {
 
         'get.candles': onCandleRequest,
         'get.settings': onSettingsRequest,
+        'get.active_algo_orders': onActiveAlgoOrdersRequest,
         'get.favourite_trading_pairs': onFavouriteTradingPairsRequest,
         'exec.bt': onBacktestExecute,
         'exec.str': onBacktestServerSideExecute,
@@ -69,9 +69,10 @@ module.exports = class APIWSServer extends WSServer {
         'api_credentials.save': onSaveAPICredentials,
         'order.submit': onOrderSubmit,
         'order.cancel': onOrderCancel,
-        'algo_order.remove': onAlgoOrderRemove,
         'algo_order.submit': onAlgoOrderSubmit,
+        'algo_order.load': onAlgoOrderLoad,
         'algo_order.cancel': onAlgoOrderCancel,
+        'algo_order.remove': onAlgoOrderRemove,
         'settings.update': onSettingsUpdate,
         'favourite_trading_pairs.save': onSaveFavouriteTradingPairs
       }
@@ -88,7 +89,6 @@ module.exports = class APIWSServer extends WSServer {
     this.restURL = restURL
 
     this.exchangeClient = new EXCHANGE_ADAPTERS[0]({})
-    this.as = new AlgoServer(algoServerParams)
   }
 
   openAlgoServerClient () {
@@ -113,33 +113,6 @@ module.exports = class APIWSServer extends WSServer {
     send(ws, ['info.auth_configured', !!credentials])
   }
 
-  async sendActiveAlgoOrders (ws) {
-    const { UserSettings } = this.db
-    const { AlgoOrder } = this.algoDB
-    const { userSettings: settings } = await UserSettings.getAll()
-    const { dms } = settings || DEFAULT_SETTINGS
-
-    if (dms) {
-      this.as.open()
-      return
-    }
-
-    const aos = await AlgoOrder.find([['active', '=', true]])
-
-    if (aos.length === 0) {
-      this.as.open()
-    } else {
-      send(ws, [
-        'info.active_algos',
-        aos.map(({ gid, algoID, state }) => {
-          state = JSON.parse(state)
-          delete state.args
-          return { gid, algoID, state }
-        })
-      ])
-    }
-  }
-
   async onWSSConnection (ws) {
     super.onWSSConnection(ws)
 
@@ -149,8 +122,6 @@ module.exports = class APIWSServer extends WSServer {
     ws.user = null
 
     await this.sendInitialConnectionData(ws)
-
-    await this.sendActiveAlgoOrders(ws)
 
     this.exchangeClient.onData((chanID, data) => {
       send(ws, ['data', 'bitfinex', chanID, data])

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bluebird": "^3.7.2",
     "debug": "^4.1.1",
     "lodash": "^4.17.11",
-    "mocha": "^6.2.0",
     "p-iteration": "^1.1.8",
     "scrypt-js": "^2.0.4",
     "sha.js": "^2.4.11",
@@ -53,5 +52,13 @@
     "test": "npm run lint && npm run unit",
     "unit": "NODE_PATH=lib NODE_ENV=test mocha"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "mocha": "^6.2.3",
+    "standard": "^16.0.3"
+  },
+  "standard": {
+    "ignore": [
+      "/docs/**/*.js"
+    ]
+  }
 }


### PR DESCRIPTION
This feature gives users the ability to load/resume the selected algo orders in case the dms feature is disabled. Having the dms feature disabled means that the server doesn't cancel the active orders automatically on HF restart/close.

Proposed solution: UI call the server endpoint `get.active_algo_orders` and then shows a popup to the user with the given array of algo orders as received in response event `algo.active_orders`. Now, the user has the ability to resume the orders with the previously saved settings and values or, the user can remove those orders. Based on user's selection, UI then sends the selected orders in an array to the HF server for them to be either cancelled or resumed.

Also, in case of websocket reopen/reconnect, the server removes all the running instances of active running orders and emits an event called `algo.cancel_orders`. This is an indication to the UI to remove all the orders from the algo tab and then call the endpoint `get.active_algo_orders`  to fetch the active orders and show them in a popup for users to resume / cancel on demand.

Note:
1. For fetching active algo orders, 
 ```
dispatch(WSActions.send([
  'get.active_algo_orders',
  authToken,
]))
```
Server then fires a `algo.active_orders` event. Example Response:
`["algo.active_orders",[{ "gid": "1611908852446", "args": {}, "label": "", "name": ""}]]`

2. For cancelling previously active orders, send the desired orders array in the following format:
```
const orders = [
  { "gid": "1611908852446", "algoID": "bfx-twap" }
]
dispatch(WSActions.send([
  'algo_order.remove',
  authToken,
  orders,
]))
```
Upon successful order cancellation, an event 'algo.orders_removed' is fired with gid of removed orders
```
["algo.orders_removed", ["1612421103100"]]
```
3. For resuming/loading previously active orders, send the desired orders array in the following format:
```
const orders = [
  { "gid": "1611908852447", "algoID": "bfx-twap" }
]
dispatch(WSActions.send([
  'algo_order.load',
  authToken,
  orders
]))
```
Upon successful order reload, an event 'algo.order_loaded' is fired with gid of resumed order
```
["algo.order.loaded", "1612421103100"]
```
Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/54