### PR TITLE
algoid added while fetching previous active algo orders

### DIFF
--- a/lib/ws_servers/api/handlers/on_active_algo_orders_request.js
+++ b/lib/ws_servers/api/handlers/on_active_algo_orders_request.js
@@ -30,9 +30,9 @@ module.exports = async (server, ws, msg) => {
 
   send(ws, [
     'algo.active_orders',
-    aos.map(({ gid, state }) => {
+    aos.map(({ gid, algoID, state }) => {
       const { args, label, name } = JSON.parse(state)
-      return { args, gid, label, name }
+      return { args, gid, algoID, label, name }
     })
   ])
 }


### PR DESCRIPTION
While submitting the selected algo orders, algoid is required to resume/cancel the algo orders. This is a fix to overcome that issue by adding the algoID in `algo.active_orders` event.

Related PR: https://github.com/bitfinexcom/bfx-hf-server/pull/66