### PR TITLE
remove active atomic orders on pop-up cancellation

### DIFF
--- a/lib/exchange_clients/bitfinex/index.js
+++ b/lib/exchange_clients/bitfinex/index.js
@@ -108,6 +108,11 @@ class BitfinexEchangeConnection {
     return socket.ws.cancelOrder(id)
   }
 
+  async submitOrderMultiOp (opPayloads) {
+    const socket = this.ws.getAuthenticatedSocket()
+    return socket.ws.submitOrderMultiOp(opPayloads)
+  }
+
   onWSError (err) {
     debug('error: %s', err.message)
   }

--- a/lib/ws_servers/api/handlers/on_algo_order_remove.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_remove.js
@@ -25,13 +25,17 @@ module.exports = async (server, ws, msg) => {
     return sendError(ws, 'Unauthorized')
   } else if (!ws.aoc) {
     return sendError(ws, 'Unauthorized')
+  } else if (!ws.clients.bitfinex) {
+    return sendError(ws, 'No client open for Bitfinex')
   }
 
+  const bfxClient = ws.clients.bitfinex
   const removedOrders = []
 
   for (const algOrder of orders) {
     const { gid, algoID } = algOrder
     try {
+      await bfxClient.submitOrderMultiOp([['oc_multi', { gid: [+gid] }]])
       const updated = await AlgoOrder.update({ gid, algoID }, { active: false })
       if (updated) removedOrders.push(gid)
     } catch (err) {


### PR DESCRIPTION
Uses the existing `submitOrderMultiOp` function to cancel the active atomic orders submitted by the user selected algo order from the pop-up when the user chooses to cancel it directly from the hf-server.