### PR TITLE
algos: pause and cleanup 

### DIFF
--- a/lib/ws_clients/algos/index.js
+++ b/lib/ws_clients/algos/index.js
@@ -67,6 +67,10 @@ module.exports = class AlgosServerClient extends WSClient {
     this.send(['close', this.userID, exID])
   }
 
+  pause (exID) {
+    this.send(['pause', this.userID, exID])
+  }
+
   openHost (exID, apiKey, apiSecret) {
     if (!this.userID) {
       return this.d('refusing to open host %s, not identified', exID)

--- a/lib/ws_servers/algos/handlers/on_identify.js
+++ b/lib/ws_servers/algos/handlers/on_identify.js
@@ -3,14 +3,8 @@
 const send = require('../../../util/ws/send')
 const sendError = require('../../../util/ws/send_error')
 const validateParams = require('../../../util/ws/validate_params')
-const exClients = require('../../../exchange_clients')
-
-const getHostKey = require('../util/get_host_key')
-
-const EX_IDS = exClients.map(exc => exc.id)
 
 module.exports = (server, ws, msg) => {
-  const { hosts } = server
   const [, userID] = msg
   const validRequest = validateParams(ws, {
     userID: { type: 'string', v: userID }
@@ -27,30 +21,4 @@ module.exports = (server, ws, msg) => {
   ws.userID = userID
 
   send(ws, ['identified', userID])
-
-  EX_IDS.forEach((exID) => {
-    const key = getHostKey(userID, exID)
-    const host = hosts[key]
-
-    if (!host) {
-      return
-    }
-
-    const instances = host.getAOInstances()
-    const activeInstances = instances.filter((aoInstance) => {
-      const { state = {} } = aoInstance
-      const { active } = state
-      return active
-    })
-
-    if (activeInstances.length === 0) {
-      return
-    }
-
-    send(ws, ['data.aos', exID, activeInstances.map((aoInstance) => {
-      const { state = {} } = aoInstance
-      const { gid, name, args, label } = state
-      return [gid, name, label, args]
-    })])
-  })
 }

--- a/lib/ws_servers/algos/handlers/on_open.js
+++ b/lib/ws_servers/algos/handlers/on_open.js
@@ -33,8 +33,14 @@ module.exports = async (server, ws, msg) => {
   const key = getHostKey(userID, exID)
   const existingHost = hosts[key]
 
+  // FIXME: move algo-server and client into bfx-hf-server
   if (existingHost) {
-    return // sendError(ws, `Algo order host already open for user on ${exID}`)
+    d('shutting down old algo host')
+    existingHost.removeAllListeners()
+    existingHost.close()
+    existingHost.cleanState()
+
+    delete hosts[key]
   }
 
   try {
@@ -83,4 +89,23 @@ module.exports = async (server, ws, msg) => {
   })
 
   send(ws, ['opened', userID, exID])
+
+  const host = hosts[key]
+
+  const instances = host.getAOInstances()
+  const activeInstances = instances.filter((aoInstance) => {
+    const { state = {} } = aoInstance
+    const { active } = state
+    return active
+  })
+
+  if (activeInstances.length === 0) {
+    return
+  }
+
+  send(ws, ['data.aos', exID, activeInstances.map((aoInstance) => {
+    const { state = {} } = aoInstance
+    const { gid, name, args, label } = state
+    return [gid, name, label, args]
+  })])
 }

--- a/lib/ws_servers/algos/handlers/on_pause.js
+++ b/lib/ws_servers/algos/handlers/on_pause.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const getHostKey = require('../util/get_host_key')
+
+module.exports = async (server, ws, msg) => {
+  const { d, hosts } = server
+  const [, userID, exID] = msg
+
+  const key = getHostKey(userID, exID)
+  const existingHost = hosts[key]
+
+  if (existingHost) {
+    d('shutting down old algo host')
+    existingHost.removeAllListeners()
+    existingHost.close()
+    existingHost.cleanState()
+
+    delete hosts[key]
+  }
+}

--- a/lib/ws_servers/algos/index.js
+++ b/lib/ws_servers/algos/index.js
@@ -13,6 +13,7 @@ const onStatus = require('./handlers/on_status')
 const onReconnect = require('./handlers/on_reconnect')
 const onIsOpen = require('./handlers/on_is_open')
 const parseHostKey = require('./util/parse_host_key')
+const onPause = require('./handlers/on_pause')
 
 module.exports = class AlgoServer extends WSServer {
   constructor ({
@@ -34,7 +35,8 @@ module.exports = class AlgoServer extends WSServer {
         open: onOpen,
         close: onClose,
         status: onStatus,
-        'is.open': onIsOpen
+        'is.open': onIsOpen,
+        pause: onPause
       }
     })
 

--- a/lib/ws_servers/api/handlers/on_algo_pause.js
+++ b/lib/ws_servers/api/handlers/on_algo_pause.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const sendError = require('../../../util/ws/send_error')
+const validateParams = require('../../../util/ws/validate_params')
+const isAuthorized = require('../../../util/ws/is_authorized')
+
+module.exports = async (server, ws, msg) => {
+  const [, authToken] = msg
+  const validRequest = validateParams(ws, {
+    authToken: { type: 'string', v: authToken }
+  })
+
+  if (!validRequest) {
+    return
+  }
+
+  if (!isAuthorized(ws, authToken)) {
+    return sendError(ws, 'Unauthorized')
+  }
+
+  ws.aoc.pause('bitfinex')
+}

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -26,6 +26,7 @@ const onOrderSubmit = require('./handlers/on_order_submit')
 const onOrderCancel = require('./handlers/on_order_cancel')
 const onAlgoOrderSubmit = require('./handlers/on_algo_order_submit')
 const onAlgoOrderCancel = require('./handlers/on_algo_order_cancel')
+const onAlgoPause = require('./handlers/on_algo_pause')
 const onSettingsUpdate = require('./handlers/on_settings_update')
 const onSettingsRequest = require('./send_settings')
 const onSaveFavouriteTradingPairs = require('./handlers/on_save_favourite_trading_pairs')
@@ -71,6 +72,7 @@ module.exports = class APIWSServer extends WSServer {
         'algo_order.load': onAlgoOrderLoad,
         'algo_order.cancel': onAlgoOrderCancel,
         'algo_order.remove': onAlgoOrderRemove,
+        'algo_order.pause': onAlgoPause,
         'settings.update': onSettingsUpdate,
         'favourite_trading_pairs.save': onSaveFavouriteTradingPairs
       }


### PR DESCRIPTION
when a user switches the app mode, the current running algo orders
should get pause. for that, the `onPause` command is added that
cleans up old state and stops the old algo server, without
removing the orders from the db.

additionally the `identify` message is called before `on_open` opens
the exchange connection for the algo host. at that point we don't
know the active instances yet. the `data.aos` event is moved to the
`on_open` handler.

the `on_open` handler for the conection will also clean up old,
orphaned algo order hosts. with a refactor that will remove the
algo server and integrates algos into the hf-api server directly,
thos state updates become easier to detect and manage.