### PR TITLE
order submit: don't spam log with standard messages

### DIFF
--- a/lib/ws_servers/api/submit_order_bitfinex.js
+++ b/lib/ws_servers/api/submit_order_bitfinex.js
@@ -11,9 +11,11 @@ module.exports = async (d, ws, bfxClient, orderPacket) => {
   try {
     await bfxClient.submitOrder(orderPacket)
 
-    d('sucessfully submitted order [bitfinex]')
+    d('sucessfully submitted order')
   } catch (error) {
-    d('failed to submit order [bitfinex]', error)
+    const txt = error.message ? error.message : error
+
+    d('failed to submit order', txt)
     notifyErrorBitfinex(ws, error)
   }
 }


### PR DESCRIPTION
in case of errors like: "not enough exchange balance" we don't
need the full stack trace which bloats the log files