### PR TITLE
handle both error object and string for algo params validation

### DIFF
--- a/lib/ws_servers/algos/util/validate_ao.js
+++ b/lib/ws_servers/algos/util/validate_ao.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _isFunction = require('lodash/isFunction')
+const _isString = require('lodash/isString')
 
 module.exports = (aoHost, aoID, payload) => {
   const ao = aoHost.getAO(aoID)
@@ -20,7 +21,7 @@ module.exports = (aoHost, aoID, payload) => {
     const err = validateParams(params)
 
     if (err) {
-      return err
+      return _isString(err) ? err : err.message
     }
   }
 


### PR DESCRIPTION
Since, the algo params validation returns error object now instead of error message, this PR adds the functionality to handle both error object and error string message.