### PR TITLE
cleanup: remove p-iteration module from sync call

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const HFDBLowDBAdapter = require('bfx-hf-models-adapter-lowdb')
 const { schema: HFDBBitfinexSchema } = require('bfx-hf-ext-plugin-bitfinex')
 const { schema: HFDBDummySchema } = require('bfx-hf-ext-plugin-dummy')
 
-const EXAS = require('./lib/exchange_clients')
+const BitfinexExchangeClient = require('./lib/exchange_clients')[0]
 const AlgoServer = require('./lib/ws_servers/algos')
 const APIWSServer = require('./lib/ws_servers/api')
 const HttpProxy = require('./lib/bfx_api_proxy')
@@ -84,7 +84,7 @@ module.exports = async ({
   const opts = { wsURL: bfxWSURL, restURL: bfxRestURL }
   async function tryConnect () {
     try {
-      await syncMarkets(apiDB, EXAS, opts)
+      await syncMarkets(apiDB, BitfinexExchangeClient, opts)
 
       proxy.open()
       as.open()

--- a/lib/exchange_clients/index.js
+++ b/lib/exchange_clients/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const BitfinexEchangeConnection = require('./bitfinex')
+const BitfinexExchangeConnection = require('./bitfinex')
 
 module.exports = [
-  BitfinexEchangeConnection
+  BitfinexExchangeConnection
 ]

--- a/lib/sync_meta.js
+++ b/lib/sync_meta.js
@@ -1,31 +1,27 @@
 'use strict'
 
-const PI = require('p-iteration')
 const debug = require('debug')('bfx:hf:server:sync-meta')
 
-module.exports = async (db, exas, opts) => {
+module.exports = async (db, EXA, opts) => {
   const { Market } = db
 
-  return PI.forEach(exas, async (EXA) => {
-    const { id } = EXA
-    const exaClient = new EXA(opts)
+  const exaClient = new EXA(opts)
 
-    debug('fetching market list for exa %s', id)
-    const markets = await exaClient.getMarkets()
-    debug('fetched %d markets for exa %s', markets.length, id)
+  debug('fetching market list')
+  const markets = await exaClient.getMarkets()
+  debug('fetched %d markets', markets.length)
 
-    // remove markets before first so we dont duplicate
-    await Market.rmAll()
-    await Market.bulkInsert(markets.map(m => ({
-      exchange: id,
-      lev: m.l,
-      quote: m.q,
-      base: m.b,
-      wsID: m.w,
-      restID: m.r,
-      uiID: m.u,
-      contexts: m.c,
-      p: m.p
-    })))
-  })
+  // remove markets before first so we dont duplicate
+  await Market.rmAll()
+  await Market.bulkInsert(markets.map(m => ({
+    exchange: EXA.id,
+    lev: m.l,
+    quote: m.q,
+    base: m.b,
+    wsID: m.w,
+    restID: m.r,
+    uiID: m.u,
+    contexts: m.c,
+    p: m.p
+  })))
 }


### PR DESCRIPTION
we just have one exchange client, no need for an async loop