### PR TITLE
Validate order params on order submit

### DIFF
--- a/lib/exchange_clients/bitfinex/get_markets.js
+++ b/lib/exchange_clients/bitfinex/get_markets.js
@@ -5,6 +5,7 @@ const _flatten = require('lodash/flatten')
 const symbolTransformer = require('./transformers/symbol')
 const filterPairs = require('./util/filter_pairs.js')
 const getMaxLevForPairs = require('./util/get_max_lev_for_pairs')
+const getMinMaxSizeForPairs = require('./util/get_min_max_size_for_pairs')
 
 module.exports = async (rest) => {
   const pairs = rest.conf([
@@ -23,18 +24,24 @@ module.exports = async (rest) => {
     'pub:spec:margin'
   ])
 
-  const [res, pe, lc] = await Promise.all([pairs, pairsToExclude, levSupportedPairs])
+  const pairInfo = rest.conf([
+    'pub:info:pair',
+    'pub:info:pair:futures'
+  ])
+
+  const [res, pe, lc, pi] = await Promise.all([pairs, pairsToExclude, levSupportedPairs, pairInfo])
 
   const symbols = _uniq(_flatten(_flatten(res)))
   const exclude = _flatten(pe)
   const lp = getMaxLevForPairs(lc)
+  const cp = getMinMaxSizeForPairs(pi)
 
   const sf = filterPairs(symbols, exclude, false)
-  const main = sf.map((sym) => symbolTransformer(res, sym, lp, { paper: false }))
+  const main = sf.map((sym) => symbolTransformer(res, sym, lp, cp, { paper: false }))
 
   const prefilteredPaper = filterPairs(symbols, pe[1], false)
   const onlyPaperPairs = filterPairs(prefilteredPaper, pe[0], true)
-  const paper = onlyPaperPairs.map((sym) => symbolTransformer(res, sym, lp, { paper: true }))
+  const paper = onlyPaperPairs.map((sym) => symbolTransformer(res, sym, lp, cp, { paper: true }))
 
   return _flatten([main, paper])
 }

--- a/lib/exchange_clients/bitfinex/transformers/symbol.js
+++ b/lib/exchange_clients/bitfinex/transformers/symbol.js
@@ -2,7 +2,7 @@
 
 const _includes = require('lodash/includes')
 
-module.exports = (symbolsByContext, sym, lc, opts) => {
+module.exports = (symbolsByContext, sym, lc, cp, opts) => {
   const { paper } = opts
   const c = []
 
@@ -21,6 +21,8 @@ module.exports = (symbolsByContext, sym, lc, opts) => {
   const b = sym.match(/:/) ? sym.split(':')[0] : sym.substring(0, 3)
   const q = sym.match(/:/) ? sym.split(':')[1] : sym.substring(3)
   const l = lc.get(sym) || 0
+  const minSize = (cp.get(sym) && cp.get(sym).minSize) || 0
+  const maxSize = (cp.get(sym) && cp.get(sym).maxSize) || 0
 
   return {
     l,
@@ -30,6 +32,8 @@ module.exports = (symbolsByContext, sym, lc, opts) => {
     u: `${b}/${q}`,
     r: `t${sym}`,
     w: `t${sym}`,
-    p: paper ? 1 : 0
+    p: paper ? 1 : 0,
+    minSize,
+    maxSize
   }
 }

--- a/lib/exchange_clients/bitfinex/util/get_min_max_size_for_pairs.js
+++ b/lib/exchange_clients/bitfinex/util/get_min_max_size_for_pairs.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = (pairInfoConfig) => {
+  const [pairInfo, futurePairInfo] = pairInfoConfig
+  const confArr = []
+
+  pairInfo.forEach(pi => {
+    const [key, [,,, minSize, maxSize]] = pi
+    confArr.push([key, { minSize: +minSize, maxSize: +maxSize }])
+  })
+
+  futurePairInfo.forEach(pi => {
+    const [key, [,,, minSize, maxSize]] = pi
+    confArr.push([key, { minSize: +minSize, maxSize: +maxSize }])
+  })
+
+  return new Map(confArr)
+}

--- a/lib/sync_meta.js
+++ b/lib/sync_meta.js
@@ -16,6 +16,8 @@ module.exports = async (db, EXA, opts) => {
   await Market.bulkInsert(markets.map(m => ({
     exchange: EXA.id,
     lev: m.l,
+    minSize: m.minSize,
+    maxSize: m.maxSize,
     quote: m.q,
     base: m.b,
     wsID: m.w,

--- a/lib/util/ws/send_invalid_order_params_error.js
+++ b/lib/util/ws/send_invalid_order_params_error.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const send = require('./send')
+
+module.exports = (ws, msg) => {
+  console.log('invalid order form params error:', msg)
+  send(ws, ['invalidOrderParams', msg])
+}

--- a/lib/ws_clients/algos/handlers/on_invalid_order_params.js
+++ b/lib/ws_clients/algos/handlers/on_invalid_order_params.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const send = require('../../../util/ws/send')
+
+module.exports = (client, msg) => {
+  const { userWS } = client
+  const [, orderParamsError] = msg
+
+  if (!userWS) {
+    return null
+  }
+
+  send(userWS, ['order.invalid_params', orderParamsError])
+}

--- a/lib/ws_clients/algos/index.js
+++ b/lib/ws_clients/algos/index.js
@@ -14,6 +14,7 @@ const onIdentified = require('./handlers/on_identified')
 const onReloadedAO = require('./handlers/on_reloaded_ao')
 const onStatus = require('./handlers/on_status')
 const onDataAOs = require('./handlers/on_data_aos')
+const onInvalidOrderParams = require('./handlers/on_invalid_order_params')
 
 const RECONNECT_INTERVAL_MS = 5 * 1000
 
@@ -36,6 +37,7 @@ module.exports = class AlgosServerClient extends WSClient {
         opened: onHostOpened,
         identified: onIdentified,
         status: onStatus,
+        invalidOrderParams: onInvalidOrderParams,
         'data.aos': onDataAOs
       }
     })

--- a/lib/ws_servers/algos/handlers/on_submit.js
+++ b/lib/ws_servers/algos/handlers/on_submit.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const sendError = require('../../../util/ws/send_error')
+const sendInvalidOrderParamsError = require('../../../util/ws/send_invalid_order_params_error')
 const validateParams = require('../../../util/ws/validate_params')
 
 const getHostKey = require('../util/get_host_key')
 const validateAO = require('../util/validate_ao')
+const validateMinMaxSize = require('../util/validate_min_max_size')
 
 module.exports = async (server, ws, msg) => {
-  const { d, hosts } = server
+  const { d, hosts, apiDB } = server
   const [, userID, exID, aoID, packet] = msg
   const validRequest = validateParams(ws, {
     exID: { type: 'string', v: exID },
@@ -35,7 +37,13 @@ module.exports = async (server, ws, msg) => {
   const validationError = validateAO(host, aoID, packet)
 
   if (validationError) {
-    return sendError(ws, validationError)
+    return sendInvalidOrderParamsError(ws, validationError)
+  }
+
+  const minMaxSizeError = await validateMinMaxSize(apiDB, packet)
+
+  if (minMaxSizeError) {
+    return sendInvalidOrderParamsError(ws, minMaxSizeError)
   }
 
   try {

--- a/lib/ws_servers/algos/util/validate_min_max_size.js
+++ b/lib/ws_servers/algos/util/validate_min_max_size.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+
+const getErrObject = (field, message) => {
+  return { field, message }
+}
+
+module.exports = async (apiDB, payload) => {
+  const { Market } = apiDB
+  const { amount, sliceAmount, _symbol } = payload
+
+  const [symbolDetail] = await Market.find([['wsID', '=', _symbol]])
+  const { minSize, maxSize } = symbolDetail || {}
+
+  if (_isFinite(amount)) {
+    if (amount < minSize) return getErrObject('amount', `Minimum size is ${minSize}`)
+    if (amount > maxSize) return getErrObject('amount', `Maximum size is ${maxSize}`)
+  }
+
+  if (_isFinite(sliceAmount)) {
+    if (sliceAmount < minSize) return getErrObject('sliceAmount', `Minimum size is ${minSize}`)
+    if (sliceAmount > maxSize) return getErrObject('sliceAmount', `Maximum size is ${maxSize}`)
+  }
+
+  return null
+}

--- a/test/get_min_max_size_for_pairs.js
+++ b/test/get_min_max_size_for_pairs.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+
+const getMinMaxSizeForPairs = require('../lib/exchange_clients/bitfinex/util/get_min_max_size_for_pairs.js')
+
+describe('get min and max size for all pairs', () => {
+  it('fetches the min and max size for all pairs', () => {
+    const pairConf = [
+      [
+        [
+          'ETHUSD',
+          [null, null, null, '0.006', '5000.0']
+        ],
+        [
+          'BTCUSD',
+          [null, null, null, '0.0002', '2000.0']
+        ]
+      ],
+      [
+        [
+          'BTCDOMF0:USTF0',
+          [null, null, null, '0.02', '100.0']
+        ]
+      ]
+    ]
+
+    const res = getMinMaxSizeForPairs(pairConf)
+    assert.deepStrictEqual(res.size, 3)
+    assert.deepStrictEqual(res.get('ETHUSD').minSize, 0.006)
+    assert.deepStrictEqual(res.get('ETHUSD').maxSize, 5000)
+    assert.deepStrictEqual(res.get('BTCUSD').minSize, 0.0002)
+    assert.deepStrictEqual(res.get('BTCUSD').maxSize, 2000)
+    assert.deepStrictEqual(res.get('BTCDOMF0:USTF0').minSize, 0.02)
+    assert.deepStrictEqual(res.get('BTCDOMF0:USTF0').maxSize, 100)
+  })
+})


### PR DESCRIPTION
- Fetches the min and max order size for market pairs
- Checks for invalid order params on order submit 
- Sends both the field and message causing that error
- UI has to check for `order.invalid_params` and view the error message on that respective field
- Example: 
```
[
"order.invalid_params",
{field: "sliceAmount", message: "Minimum size is 0.002"}
]
```
