### PR TITLE
support submit of multiple api keys

### DIFF
--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -8,7 +8,7 @@ const validateParams = require('../../../util/ws/validate_params')
 const {
   notifyInternalError, notifySuccess, notifyError
 } = require('../../../util/ws/notify')
-const validExchange = require('../../../util/valid_exchange')
+
 const verifyPassword = require('../../../util/verify_password')
 const encryptAPICredentials = require('../../../util/encrypt_api_credentials')
 const isAuthorized = require('../../../util/ws/is_authorized')
@@ -17,22 +17,22 @@ const openAuthBitfinexConnection = require('../open_auth_bitfinex_connection')
 
 module.exports = async (server, ws, msg) => {
   const { d, db, wsURL, restURL } = server
-  const [, authToken, exID, apiKey, apiSecret, mode] = msg
+  const [, authToken, apiKey, apiSecret, formSent, mode] = msg
   const validRequest = validateParams(ws, {
-    exID: { type: 'string', v: exID },
     authToken: { type: 'string', v: authToken },
     apiKey: { type: 'string', v: apiKey },
     apiSecret: { type: 'string', v: apiSecret },
+    formSent: { type: 'string', v: formSent },
     mode: { type: 'string', v: mode }
   })
+
+  const exID = 'bitfinex' // legacy support
 
   if (!validRequest) {
     d('save credentials: invalid request')
     return
   } else if (!isAuthorized(ws, authToken)) {
     return sendError(ws, 'Unauthorized')
-  } else if (!validExchange(exID)) {
-    return sendError(ws, 'Unrecognised exchange, cannot save API credentials')
   }
 
   // TODO: Move into isAuthorized()
@@ -51,7 +51,7 @@ module.exports = async (server, ws, msg) => {
 
   const { Credential } = db
   const credentials = await encryptAPICredentials({
-    exID: exID + mode,
+    exID: exID + formSent,
     password: ws.authPassword,
     key: apiKey,
     secret: apiSecret,
@@ -60,15 +60,19 @@ module.exports = async (server, ws, msg) => {
 
   await Credential.set(credentials)
 
-  d('saved API credentials for %s', exID)
+  d('saved API credentials for Bitfinex')
+
+  notifySuccess(ws, `Encrypted API credentials saved for ${_capitalize(exID)}`)
+  send(ws, ['data.api_credentials.configured', exID])
+
+  if (formSent !== mode) {
+    return
+  }
 
   ws[`${exID}Credentials`] = {
     key: apiKey,
     secret: apiSecret
   }
-
-  notifySuccess(ws, `Encrypted API credentials saved for ${_capitalize(exID)}`)
-  send(ws, ['data.api_credentials.configured', exID])
 
   d('issuing API & Algo reconnect due to credentials change')
 


### PR DESCRIPTION
the ui displays both paper and main api keys in the settings now
and sends both to the server. this change supports a new parameter
that identifies the api key that was submitted.

additionally a reconnect to the api is just done when the app is
running in the mode the api key was submitted for.

support for the fix in https://github.com/bitfinexcom/bfx-hf-ui/pull/353