### PR TITLE
Fix ghost "auth failed" notifications

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -12,6 +12,7 @@ class AlgoWorker {
   constructor (settings, algoOrders, bcast, algoDB) {
     this.host = null
     this.userID = null
+    this.isStarted = false
 
     this.settings = settings
     this.algoOrders = algoOrders
@@ -56,6 +57,7 @@ class AlgoWorker {
     this.pub(['opened', userID, 'bitfinex'])
 
     this.sendActiveAlgos()
+    this.isStarted = true
   }
 
   sendActiveAlgos () {

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -89,7 +89,7 @@ module.exports = async (server, ws, msg) => {
 
   notifySuccess(ws, 'Reconnecting with new credentials...')
 
-  if (ws.algoWorker.started) {
+  if (ws.algoWorker.isStarted) {
     return
   }
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1125859137800433/1200297512392067

`ws.algoWorker.started` was always false, so every time the Save button was clicked, a new connection was created using `openAuthBitfinexConnection` method. Because of this, previous connections with the wrong key had been provoked an infinite reconnection. 