### PR TITLE
algos: reduce db writes

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -114,11 +114,6 @@ class AlgoWorker {
       d('meta reloaded')
       this.pub(['algo.reload'])
     })
-
-    this.host.on('ao:loaded', (gid) => {
-      d('ao loaded: %s', gid)
-      this.pub(['algo.order_loaded', gid])
-    })
   }
 
   async _updateAlgo (updateOpts) {

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -110,30 +110,6 @@ class AlgoWorker {
       this.sendError(`error: ${error}`)
     })
 
-    this.host.on('ao:start', (instance) => {
-      const { state = {} } = instance
-      const { name, label, args, gid } = state
-
-      d('ao started: %s %s', name, label)
-
-      this.sendSuccess(`Started AO ${name} on Bitfinex`)
-      this.pub(['data.ao', 'bitfinex', { gid, name, label, args }])
-    })
-
-    this.host.on('ao:stop', (instance) => {
-      const { state = {} } = instance
-      const { gid } = state
-
-      d('ao stopped: %s', gid)
-
-      this.sendSuccess('Stopped algo order')
-      this.pub(['data.ao.stopped', 'bitfinex', gid])
-    })
-
-    this.host.on('ao:persist:db:update', async (updateOpts) => {
-      await this._updateAlgo(updateOpts)
-    })
-
     this.host.on('meta:reload', async () => {
       d('meta reloaded')
       this.pub(['algo.reload'])
@@ -151,6 +127,18 @@ class AlgoWorker {
     d('ao instance updated %s', updateOpts.gid)
   }
 
+  async storeState () {
+    const { host } = this
+
+    const algos = host.getSerializedAlgos()
+
+    await Promise.all(
+      algos.map(async (updateOpts) => {
+        await this._updateAlgo(updateOpts)
+      })
+    )
+  }
+
   sendSuccess (msg) {
     this.pub(['notify', 'success', msg])
   }
@@ -162,11 +150,20 @@ class AlgoWorker {
   async cancelOrder (gid) {
     const { host } = this
 
-    if (!host.getAOInstance(gid)) {
+    const instance = host.getAOInstance(gid)
+    if (!instance) {
       throw new Error('Requested algo order not running, cannot stop')
     }
 
+    const serialized = host.getSerializedAO(instance)
+    serialized.active = false
+    this._updateAlgo(serialized)
+
     await host.stopAO(gid)
+
+    this.sendSuccess('Stopped algo order')
+    this.pub(['data.ao.stopped', 'bitfinex', gid])
+
     d('stopped AO for user %s on gid: %s', this.userID, gid)
   }
 
@@ -180,8 +177,14 @@ class AlgoWorker {
     }
 
     try {
-      const gid = await host.startAO(aoID, order)
-      d('started AO for user %s on [%s]', this.userID, gid)
+      const [serialized, uiData] = await host.startAO(aoID, order)
+      const { name, label, args, gid } = uiData
+      d('ao started: %s %s', name, label)
+
+      this._updateAlgo(serialized)
+
+      this.sendSuccess(`Started AO ${name} on Bitfinex`)
+      this.pub(['data.ao', 'bitfinex', { gid, name, label, args }])
     } catch (e) {
       d('error starting AO %s: %s for %s: %s', aoID, e, this.userID, e.stack)
 

--- a/lib/ws_servers/api/handlers/on_algo_order_load.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_load.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const send = require('../../../util/ws/send')
 const sendError = require('../../../util/ws/send_error')
 const validateParams = require('../../../util/ws/validate_params')
 const isAuthorized = require('../../../util/ws/is_authorized')
@@ -38,9 +39,13 @@ module.exports = async (server, ws, msg) => {
       state = JSON.parse(state)
       state.active = true
 
-      ws.algoWorker.host.loadAO(algoID, gid, state)
+      const [, uiData] = await ws.algoWorker.host.loadAO(algoID, gid, state)
+      const { name, label, args } = uiData
 
       d('AO loaded for user %s [%s]', 'HF_UI', gid)
+
+      send(ws, ['algo.order_loaded', gid])
+      send(ws, ['data.ao', 'bitfinex', { gid, name, label, args }])
     } catch (e) {
       d('error loading AO %s: %s', algoID, e.stack)
       sendError(ws, `Failed to start algo order: ${algoID}`)

--- a/lib/ws_servers/api/handlers/on_algo_pause.js
+++ b/lib/ws_servers/api/handlers/on_algo_pause.js
@@ -19,6 +19,7 @@ module.exports = async (server, ws, msg) => {
   }
 
   try {
+    await ws.algoWorker.storeState()
     await ws.algoWorker.close()
   } catch (e) {
     return sendError(ws, e.message)


### PR DESCRIPTION
this PR fixes the permanent writes an algo order does to the db,
preparing many threads running many different algo orders.

previously, each algo order would keep writing to the
database in short intervals. i.e. a twap order with an
interval set to 2 seconds, would write to the db every two
seconds, with no real use case.. with 100 twaps, we end up
with over 50 writes per second.

with this PR an algo order is saved to the database at three
occurences:

1. on creation / start of the algo order
2. when the algo order is stopped and set inactive
3. when the HF UI is closed or switched into paper trading,
   so the algo orders can get resumed with the old state

related:

https://github.com/bitfinexcom/bfx-hf-ui/pull/407
https://github.com/bitfinexcom/bfx-hf-algo/pull/143