### PR TITLE
update ui with ao stop event

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -115,6 +115,12 @@ class AlgoWorker {
       d('meta reloaded')
       this.pub(['algo.reload'])
     })
+
+    this.host.on('ao:stopped', (gid) => {
+      this.sendSuccess('Stopped algo order')
+      this.pub(['data.ao.stopped', 'bitfinex', gid])
+      d('stopped AO for user %s on gid: %s', this.userID, gid)
+    })
   }
 
   async _updateAlgo (updateOpts) {
@@ -156,11 +162,6 @@ class AlgoWorker {
     this._updateAlgo(serialized)
 
     await host.stopAO(gid)
-
-    this.sendSuccess('Stopped algo order')
-    this.pub(['data.ao.stopped', 'bitfinex', gid])
-
-    d('stopped AO for user %s on gid: %s', this.userID, gid)
   }
 
   async submitOrder (aoID, order) {


### PR DESCRIPTION
Since, algo order can be stopped for various reasons, it is required to update the UI whenever algo is stopped and not just when the user cancels it manually. So, a new event `ao:stopped` is registered in server and is emitted by the host whenever the algo is stopped. 

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/152