### PR TITLE
Show algo pause info

### DIFF
--- a/lib/ws_servers/api/handlers/on_algo_pause_info_request.js
+++ b/lib/ws_servers/api/handlers/on_algo_pause_info_request.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const _isEmpty = require('lodash/isEmpty')
+const send = require('../../../util/ws/send')
+
+const { _default: { showAlgoPauseInfo: defaultShowAlgoPauseInfo } } = require('bfx-hf-ui-config').UserSettings
+
+module.exports = async (server, ws, msg) => {
+  const { algoDB, db } = server
+  const { AlgoOrder } = algoDB
+  const { UserSettings } = db
+
+  const [{ userSettings = {} }, aos = []] = await Promise.all([
+    UserSettings.getAll(),
+    AlgoOrder.find([['active', '=', true]])
+  ])
+
+  const showAlgoPauseInfo = _isEmpty(userSettings)
+    ? defaultShowAlgoPauseInfo
+    : userSettings.showAlgoPauseInfo
+
+  if (!showAlgoPauseInfo || aos.length === 0) {
+    send(ws, ['data.show_algo_pause_info', false])
+    return
+  }
+
+  send(ws, ['data.show_algo_pause_info', true])
+}

--- a/lib/ws_servers/api/handlers/on_settings_update.js
+++ b/lib/ws_servers/api/handlers/on_settings_update.js
@@ -12,11 +12,12 @@ const {
 module.exports = async (server, ws, msg) => {
   const { d, db, reconnectAlgoHost } = server
   const { UserSettings } = db
-  const [, authToken, dms, ga] = msg
+  const [, authToken, dms, ga, showAlgoPauseInfo] = msg
 
   const validRequest = validateParams(ws, {
     dms: { type: 'bool', v: dms },
-    ga: { type: 'bool', v: ga }
+    ga: { type: 'bool', v: ga },
+    showAlgoPauseInfo: { type: 'bool', v: showAlgoPauseInfo }
   })
 
   if (!validRequest) {
@@ -29,7 +30,8 @@ module.exports = async (server, ws, msg) => {
   const settings = {
     ga,
     dms,
-    affiliateCode
+    affiliateCode,
+    showAlgoPauseInfo
   }
 
   await UserSettings.set(settings)

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -24,6 +24,7 @@ const onSettingsUpdate = require('./handlers/on_settings_update')
 const onSettingsRequest = require('./send_settings')
 const onSaveFavouriteTradingPairs = require('./handlers/on_save_favourite_trading_pairs')
 const onFavouriteTradingPairsRequest = require('./handlers/on_favourite_trading_pairs_request')
+const onShowAlgoPauseInfoRequest = require('./handlers/on_algo_pause_info_request')
 
 const AlgoWorker = require('./algos/algo_worker')
 const { _default: DEFAULT_USER_SETTINGS } = require('bfx-hf-ui-config').UserSettings
@@ -54,6 +55,7 @@ module.exports = class APIWSServer extends WSServer {
         'get.settings': onSettingsRequest,
         'get.active_algo_orders': onActiveAlgoOrdersRequest,
         'get.favourite_trading_pairs': onFavouriteTradingPairsRequest,
+        'get.show_algo_pause_info': onShowAlgoPauseInfoRequest,
 
         'strategy.save': onSaveStrategy,
         'strategy.remove': onRemoveStrategy,


### PR DESCRIPTION
- Added new endpoint `get.show_algo_pause_info` which is used to request if the algo pause info should be shown or not
- `data.show_algo_pause_info` event then returns either `true` or `false` so that the UI is notified whether the algo pause info should be shown or not
- Updated `settings.update` endpoint to add option `showAlgoPauseInfo` which can be used when the user selects `Don't show again` option when the algo pause info pop-up is shown.

Params required for endpoints:
- `dispatch(WSActions.send(['get.show_algo_pause_info']))`
- `dispatch(WSActions.send(['settings.update', authToken, dms, ga, showAlgoPauseInfo]))`

Depends on: https://github.com/bitfinexcom/bfx-hf-ui-config/pull/8
Task: https://app.asana.com/0/1125859137800433/1199687611133172/f