### PR TITLE
check for host before updating auth Args

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -92,6 +92,10 @@ class AlgoWorker {
   }
 
   updateAuthArgs (args = {}) {
+    if (!this.host) {
+      return
+    }
+
     const adapter = this.host.getAdapter()
 
     if (adapter.updateAuthArgs) {


### PR DESCRIPTION
Fix issue while updating auth args if AO Host is not started yet.
 
Task: https://app.asana.com/0/1125859137800433/1200669195976789