### PR TITLE
Display 'submitted', 'executed' and 'cancelled' notifications

### DIFF
--- a/lib/util/ws/adapters/index.js
+++ b/lib/util/ws/adapters/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const receiveOrder = require('./order')
+
+module.exports = {
+  receiveOrder
+}

--- a/lib/util/ws/adapters/order.js
+++ b/lib/util/ws/adapters/order.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = (data = []) => ({
+  id: data[0],
+  gid: data[1],
+  cid: data[2],
+  symbol: data[3],
+  created: data[4],
+  amount: data[5],
+  originalAmount: data[6],
+  type: data[7],
+  status: data[8],
+  price: data[9]
+})

--- a/lib/util/ws/notify/index.js
+++ b/lib/util/ws/notify/index.js
@@ -6,6 +6,7 @@ const notifySuccess = require('./success')
 const notifyErrorBitfinex = require('./error_bitfinex')
 const notifyOrderExecuted = require('./order_executed')
 const notifyOrderCancelled = require('./order_cancelled')
+const notifyOrderSubmitted = require('./order_submitted')
 const notifyInternalError = require('./internal_error')
 
 module.exports = {
@@ -15,5 +16,6 @@ module.exports = {
   notifyErrorBitfinex,
   notifyOrderExecuted,
   notifyOrderCancelled,
+  notifyOrderSubmitted,
   notifyInternalError
 }

--- a/lib/util/ws/notify/order_cancelled.js
+++ b/lib/util/ws/notify/order_cancelled.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const _capitalize = require('lodash/capitalize')
+const _lowerCase = require('lodash/lowerCase')
 const notifySuccess = require('./success')
 
 module.exports = (ws, exID, order) => {
-  const { amount, symbol, price, type } = order
+  const { id, amount, symbol, type } = order
 
   notifySuccess(ws, [
-    'Cancelled', _capitalize(exID), type, amount > 0 ? 'BUY' : 'SELL',
-    'order on', `${symbol}:`, +amount, '@', price
+    _capitalize(exID), _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
+    'order of', +amount, symbol, 'has been canceled',
+    `(ID: ${id})`
   ].join(' '))
 }

--- a/lib/util/ws/notify/order_cancelled.js
+++ b/lib/util/ws/notify/order_cancelled.js
@@ -5,11 +5,11 @@ const notifyInfo = require('./info')
 const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
-  const { id, amount, symbol, type } = order
+  const { id, originalAmount, symbol, type } = order
 
   notifyInfo(ws, format([
-    exID, _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
-    'order of', +amount, symbol, 'has been canceled',
+    exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
+    'order of', Math.abs(+originalAmount), symbol, 'has been canceled',
     `(ID: ${id})`
   ]))
 }

--- a/lib/util/ws/notify/order_cancelled.js
+++ b/lib/util/ws/notify/order_cancelled.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const _capitalize = require('lodash/capitalize')
 const _lowerCase = require('lodash/lowerCase')
 const notifyInfo = require('./info')
+const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, symbol, type } = order
 
-  notifyInfo(ws, [
-    _capitalize(exID), _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
+  notifyInfo(ws, format([
+    exID, _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
     'order of', +amount, symbol, 'has been canceled',
     `(ID: ${id})`
-  ].join(' '))
+  ]))
 }

--- a/lib/util/ws/notify/order_cancelled.js
+++ b/lib/util/ws/notify/order_cancelled.js
@@ -2,12 +2,12 @@
 
 const _capitalize = require('lodash/capitalize')
 const _lowerCase = require('lodash/lowerCase')
-const notifySuccess = require('./success')
+const notifyInfo = require('./info')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, symbol, type } = order
 
-  notifySuccess(ws, [
+  notifyInfo(ws, [
     _capitalize(exID), _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
     'order of', +amount, symbol, 'has been canceled',
     `(ID: ${id})`

--- a/lib/util/ws/notify/order_executed.js
+++ b/lib/util/ws/notify/order_executed.js
@@ -3,14 +3,16 @@
 const _flatten = require('lodash/flatten')
 const _isFinite = require('lodash/isFinite')
 const _capitalize = require('lodash/capitalize')
+const _lowerCase = require('lodash/lowerCase')
 const notifySuccess = require('./success')
 
 module.exports = (ws, exID, order) => {
-  const { amount, symbol, price, type } = order
+  const { id, amount, symbol, price, type } = order
 
   notifySuccess(ws, _flatten([
-    'Executed', _capitalize(exID), type, amount > 0 ? 'BUY' : 'SELL',
-    'order on', `${symbol}`,
-    _isFinite(+amount) && _isFinite(+price) && +price > 0 && [+amount, '@', price]
+    _capitalize(exID), _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
+    'order of', _isFinite(+amount) && +amount, symbol,
+    'has been fully executed', isFinite(+price) && +price > 0 && ['at', price],
+    `(ID: ${id})`
   ]).filter(t => !!t).join(' '))
 }

--- a/lib/util/ws/notify/order_executed.js
+++ b/lib/util/ws/notify/order_executed.js
@@ -6,11 +6,11 @@ const notifySuccess = require('./success')
 const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
-  const { id, amount, symbol, price, type } = order
+  const { id, originalAmount, symbol, price, type } = order
 
   notifySuccess(ws, format([
-    exID, _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
-    'order of', _isFinite(+amount) && +amount, symbol,
+    exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
+    'order of', _isFinite(+originalAmount) && Math.abs(+originalAmount), symbol,
     'has been fully executed', isFinite(+price) && +price > 0 && ['at', price],
     `(ID: ${id})`
   ]))

--- a/lib/util/ws/notify/order_executed.js
+++ b/lib/util/ws/notify/order_executed.js
@@ -1,18 +1,17 @@
 'use strict'
 
-const _flatten = require('lodash/flatten')
 const _isFinite = require('lodash/isFinite')
-const _capitalize = require('lodash/capitalize')
 const _lowerCase = require('lodash/lowerCase')
 const notifySuccess = require('./success')
+const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, symbol, price, type } = order
 
-  notifySuccess(ws, _flatten([
-    _capitalize(exID), _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
+  notifySuccess(ws, format([
+    exID, _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
     'order of', _isFinite(+amount) && +amount, symbol,
     'has been fully executed', isFinite(+price) && +price > 0 && ['at', price],
     `(ID: ${id})`
-  ]).filter(t => !!t).join(' '))
+  ]))
 }

--- a/lib/util/ws/notify/order_submitted.js
+++ b/lib/util/ws/notify/order_submitted.js
@@ -2,15 +2,16 @@
 
 const _flatten = require('lodash/flatten')
 const _isFinite = require('lodash/isFinite')
-const _capitalize = require('lodash/capitalize')
+const _lowerCase = require('lodash/lowerCase')
 const notifySuccess = require('./success')
 
 module.exports = (ws, exID, order) => {
-  const { amount, symbol, price, type } = order
+  const { id, amount, symbol, price, type } = order
 
   notifySuccess(ws, _flatten([
-    'Submitted ', _capitalize(exID), type, amount > 0 ? 'BUY' : 'SELL',
-    'order on', `${symbol}`,
-    _isFinite(+amount) && _isFinite(+price) && +price > 0 && [+amount, '@', price]
+    'Created ', exID, _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
+    'order of', _isFinite(+amount) && amount, symbol,
+    _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
+    `(ID: ${id})`
   ]).filter(t => !!t).join(' '))
 }

--- a/lib/util/ws/notify/order_submitted.js
+++ b/lib/util/ws/notify/order_submitted.js
@@ -1,17 +1,17 @@
 'use strict'
 
-const _flatten = require('lodash/flatten')
 const _isFinite = require('lodash/isFinite')
 const _lowerCase = require('lodash/lowerCase')
 const notifySuccess = require('./success')
+const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, symbol, price, type } = order
 
-  notifySuccess(ws, _flatten([
+  notifySuccess(ws, format([
     'Created ', exID, _lowerCase(type), amount > 0 ? 'BUY' : 'SELL',
     'order of', _isFinite(+amount) && amount, symbol,
     _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
     `(ID: ${id})`
-  ]).filter(t => !!t).join(' '))
+  ]))
 }

--- a/lib/util/ws/notify/order_submitted.js
+++ b/lib/util/ws/notify/order_submitted.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const _flatten = require('lodash/flatten')
+const _isFinite = require('lodash/isFinite')
+const _capitalize = require('lodash/capitalize')
+const notifySuccess = require('./success')
+
+module.exports = (ws, exID, order) => {
+  const { amount, symbol, price, type } = order
+
+  notifySuccess(ws, _flatten([
+    'Submitted ', _capitalize(exID), type, amount > 0 ? 'BUY' : 'SELL',
+    'order on', `${symbol}`,
+    _isFinite(+amount) && _isFinite(+price) && +price > 0 && [+amount, '@', price]
+  ]).filter(t => !!t).join(' '))
+}

--- a/lib/util/ws/notify/util/format.js
+++ b/lib/util/ws/notify/util/format.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const _flatten = require('lodash/flatten')
+const _capitalize = require('lodash/capitalize')
+
+module.exports = (message) => {
+  const [first, ...rest] = message
+
+  return _flatten([
+    _capitalize(first), ...rest
+  ]).filter(t => !!t).join(' ')
+}

--- a/lib/ws_servers/api/cancel_order_bitfinex.js
+++ b/lib/ws_servers/api/cancel_order_bitfinex.js
@@ -2,7 +2,6 @@
 
 const {
   notifyInfo,
-  notifyOrderCancelled,
   notifyErrorBitfinex
 } = require('../../util/ws/notify')
 
@@ -10,15 +9,9 @@ module.exports = async (d, ws, bfxClient, symbol, id) => {
   notifyInfo(ws, 'Cancelling order on Bitfinex')
 
   try {
-    const order = await bfxClient.cancelOrder(id)
+    await bfxClient.cancelOrder(id)
 
     d('sucessfully cancelled order [bitfinex]')
-    notifyOrderCancelled(ws, 'bitfinex', {
-      amount: order[7],
-      symbol: order[3],
-      price: order[16],
-      type: order[8]
-    })
   } catch (error) {
     d('failed to cancel order [bitfinex]')
     notifyErrorBitfinex(ws, error)

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -5,7 +5,8 @@ const _isString = require('lodash/isString')
 const _isEmpty = require('lodash/isEmpty')
 const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
 const BitfinexExchangeConnection = require('../../exchange_clients/bitfinex')
-const { notifyInfo, notifyError, notifySuccess } = require('../../util/ws/notify')
+const { notifyInfo, notifyError, notifySuccess, notifyOrderCancelled, notifyOrderExecuted, notifyOrderSubmitted } = require('../../util/ws/notify')
+const { receiveOrder } = require('../../util/ws/adapters')
 const send = require('../../util/ws/send')
 const { WS_CONNECTION, DMS_ENABLED } = require('../../constants')
 
@@ -56,9 +57,23 @@ module.exports = async (conf) => {
       case 'pu': return send(ws, ['data.position', 'bitfinex', msgData])
       case 'pc': return send(ws, ['data.position.close', 'bitfinex', msgData])
       case 'os': return send(ws, ['data.orders', 'bitfinex', msgData])
-      case 'on':
+      case 'on': {
+        const order = receiveOrder(msgData)
+
+        notifyOrderSubmitted(ws, 'bitfinex', order)
+        return send(ws, ['data.order', 'bitfinex', msgData])
+      }
       case 'ou': return send(ws, ['data.order', 'bitfinex', msgData])
-      case 'oc': return send(ws, ['data.order.close', 'bitfinex', msgData])
+      case 'oc': {
+        const order = receiveOrder(msgData)
+
+        if (order.status.includes('CANCELED')) {
+          notifyOrderCancelled(ws, 'bitfinex', order)
+        } else if (order.status.includes('EXECUTED')) {
+          notifyOrderExecuted(ws, 'bitfinex', order)
+        }
+        return send(ws, ['data.order.close', 'bitfinex', msgData])
+      }
       case 'n': {
         let [,,,, ucmPayload,, status, text] = msgData
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1125859137800433/1200582249626724/f

Added notifications:
- submitted order
![image](https://user-images.githubusercontent.com/70510980/128531358-1f43ebe7-1547-438a-8096-48dc9a282d33.png)
- executed order
![image](https://user-images.githubusercontent.com/70510980/128531414-ca4cdab4-9d94-4037-99a5-82628690b7ca.png)
- cancelled order (was present only for order cancellation by HF)
![image](https://user-images.githubusercontent.com/70510980/128531311-88568ab5-556c-427d-9f04-1180ffbdd6e4.png)

Updated notification type for cancellation from 'succes' (green) to 'info ('blue)

