### PR TITLE
I18N

### DIFF
--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function apply (params) {
+  if (!params) return undefined
+  if ('key' in params) return params
+  return { key: params[0], props: params[1] }
+}
+
+module.exports = {
+  apply
+}

--- a/lib/util/ws/notify/error.js
+++ b/lib/util/ws/notify/error.js
@@ -1,7 +1,8 @@
 'use strict'
 
+const { apply } = require('../../../util/i18n')
 const send = require('../send')
 
-module.exports = (ws, msg) => {
-  send(ws, ['notify', 'error', msg])
+module.exports = (ws, msg, i18n) => {
+  send(ws, ['notify', 'error', msg, apply(i18n)])
 }

--- a/lib/util/ws/notify/info.js
+++ b/lib/util/ws/notify/info.js
@@ -1,7 +1,8 @@
 'use strict'
 
+const { apply } = require('../../../util/i18n')
 const send = require('../send')
 
-module.exports = (ws, msg) => {
-  send(ws, ['notify', 'info', msg])
+module.exports = (ws, msg, i18n) => {
+  send(ws, ['notify', 'info', msg, apply(i18n)])
 }

--- a/lib/util/ws/notify/internal_error.js
+++ b/lib/util/ws/notify/internal_error.js
@@ -3,5 +3,5 @@
 const notifyError = require('./error')
 
 module.exports = (ws) => {
-  return notifyError(ws, 'Internal server error')
+  return notifyError(ws, 'Internal server error', ['internalServerError'])
 }

--- a/lib/util/ws/notify/order_cancelled.js
+++ b/lib/util/ws/notify/order_cancelled.js
@@ -11,5 +11,13 @@ module.exports = (ws, exID, order) => {
     exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
     'order of', Math.abs(+originalAmount), symbol, 'has been canceled',
     `(ID: ${id})`
-  ]))
+  ]), [
+    originalAmount > 0 ? 'orderCancelledBuy.detailed' : 'orderCancelledSell.detailed', {
+      exID,
+      type,
+      symbol,
+      amount: Math.abs(+originalAmount),
+      id
+    }
+  ])
 }

--- a/lib/util/ws/notify/order_executed.js
+++ b/lib/util/ws/notify/order_executed.js
@@ -13,5 +13,14 @@ module.exports = (ws, exID, order) => {
     'order of', _isFinite(+originalAmount) && Math.abs(+originalAmount), symbol,
     'has been fully executed', isFinite(+price) && +price > 0 && ['at', price],
     `(ID: ${id})`
-  ]))
+  ]), [
+    `orderExecuted${originalAmount > 0 ? 'Buy' : 'Sell'}${isFinite(+price) && +price > 0 ? 'At' : ''}.detailed`, {
+      exID,
+      type,
+      symbol,
+      price,
+      amount: Math.abs(+originalAmount),
+      id
+    }
+  ])
 }

--- a/lib/util/ws/notify/order_submitted.js
+++ b/lib/util/ws/notify/order_submitted.js
@@ -13,5 +13,14 @@ module.exports = (ws, exID, order) => {
     'order of', _isFinite(+amount) && amount, symbol,
     _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
     `(ID: ${id})`
-  ]))
+  ]), [
+    `orderSubmitted${amount > 0 ? 'Buy' : 'Sell'}${isFinite(+price) && +price > 0 ? 'At' : ''}.detailed`, {
+      exID,
+      type,
+      symbol,
+      amount,
+      price,
+      id
+    }
+  ])
 }

--- a/lib/util/ws/notify/success.js
+++ b/lib/util/ws/notify/success.js
@@ -1,7 +1,8 @@
 'use strict'
 
+const { apply } = require('../../../util/i18n')
 const send = require('../send')
 
-module.exports = (ws, msg) => {
-  send(ws, ['notify', 'success', msg])
+module.exports = (ws, msg, i18n) => {
+  send(ws, ['notify', 'success', msg, apply(i18n)])
 }

--- a/lib/util/ws/send_error.js
+++ b/lib/util/ws/send_error.js
@@ -2,7 +2,7 @@
 
 const send = require('./send')
 
-module.exports = (ws, msg) => {
+module.exports = (ws, msg, i18n) => {
   console.error('websocket error:', msg)
-  send(ws, ['error', msg])
+  send(ws, ['error', msg, i18n])
 }

--- a/lib/util/ws/send_error.js
+++ b/lib/util/ws/send_error.js
@@ -1,8 +1,9 @@
 'use strict'
 
+const { apply } = require('../../util/i18n')
 const send = require('./send')
 
 module.exports = (ws, msg, i18n) => {
   console.error('websocket error:', msg)
-  send(ws, ['error', msg, i18n])
+  send(ws, ['error', msg, apply(i18n)])
 }

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -201,7 +201,7 @@ class AlgoWorker {
     const validationError = validateAO(host, marketData, aoID, order)
 
     if (validationError) {
-      throw new Error(validationError)
+      throw validationError
     }
 
     const ao = host.startAO(aoID, order)

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -186,7 +186,10 @@ class AlgoWorker {
 
     const instance = host.getAOInstance(gid)
     if (!instance) {
-      throw new Error('Requested algo order not running, cannot stop')
+      const error = new Error('Requested algo order not running, cannot stop')
+
+      error.i18n = applyI18N(['requestedAlgoOrderNotRunningCannotStop'])
+      throw error
     }
 
     const serialized = host.getSerializedAO(instance)

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -6,6 +6,7 @@ const { AOHost } = require('bfx-hf-algo')
 const PluginBfxAdapter = require('bfx-hf-token-renewal-plugin/lib/adapters/bitfinex-adapter')
 const TokenRenewalPlugin = require('bfx-hf-token-renewal-plugin')
 
+const { apply: applyI18N } = require('../../../util/i18n')
 const validateAO = require('./util/validate_ao')
 const { DMS_ENABLED } = require('../../../constants')
 
@@ -148,7 +149,7 @@ class AlgoWorker {
       serialized.active = false
       await this._updateAlgo(serialized)
 
-      this.sendSuccess('Stopped algo order')
+      this.sendSuccess('Stopped algo order', ['stoppedAO'])
       this.pub(['data.ao.stopped', 'bitfinex', gid])
       d('stopped AO for user %s on gid: %s', this.userId, gid)
     })
@@ -172,8 +173,8 @@ class AlgoWorker {
     )
   }
 
-  sendSuccess (msg) {
-    this.pub(['notify', 'success', msg])
+  sendSuccess (msg, i18n) {
+    this.pub(['notify', 'success', msg, applyI18N(i18n)])
   }
 
   sendError (err) {
@@ -228,7 +229,7 @@ class AlgoWorker {
 
       await this._updateAlgo(serialized)
 
-      this.sendSuccess(`Started AO ${name} on Bitfinex`)
+      this.sendSuccess(`Started AO ${name} on Bitfinex`, ['startedAO', { name, target: 'Bitfinex' }])
       this.pub(['data.ao', 'bitfinex', { gid, name, label, args }])
       return gid
     } catch (e) {

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -224,13 +224,13 @@ class AlgoWorker {
     try {
       const [serialized, uiData] = await ao
 
-      const { name, label, args, gid } = uiData
+      const { name, label, args, gid, i18n } = uiData
       d('ao started: %s %s', name, label)
 
       await this._updateAlgo(serialized)
 
       this.sendSuccess(`Started AO ${name} on Bitfinex`, ['startedAO', { name, target: 'Bitfinex' }])
-      this.pub(['data.ao', 'bitfinex', { gid, name, label, args }])
+      this.pub(['data.ao', 'bitfinex', { gid, name, label, args, i18n }])
       return gid
     } catch (e) {
       d('error starting AO %s: %s for %s: %s', aoID, e, this.userId, e.stack)

--- a/lib/ws_servers/api/algos/util/validate_ao.js
+++ b/lib/ws_servers/api/algos/util/validate_ao.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const _isFunction = require('lodash/isFunction')
-const _isString = require('lodash/isString')
 
 module.exports = (aoHost, marketData, aoID, payload) => {
   const ao = aoHost.getAO(aoID)
@@ -25,10 +24,5 @@ module.exports = (aoHost, marketData, aoID, payload) => {
     ? processParams(payload)
     : { ...payload }
 
-  const err = validateParams(params, symbolDetail)
-  if (err) {
-    return _isString(err) ? err : err.message
-  }
-
-  return null
+  return validateParams(params, symbolDetail)
 }

--- a/lib/ws_servers/api/algos/util/validate_ao.js
+++ b/lib/ws_servers/api/algos/util/validate_ao.js
@@ -1,12 +1,16 @@
 'use strict'
 
 const _isFunction = require('lodash/isFunction')
+const { apply } = require('../../../../util/i18n')
 
 module.exports = (aoHost, marketData, aoID, payload) => {
   const ao = aoHost.getAO(aoID)
 
   if (!ao) {
-    return `Unknown algo order ID: ${aoID}`
+    return {
+      message: `Unknown algo order ID: ${aoID}`,
+      i18n: apply(['unknownAlgoOrderId', { aoID }])
+    }
   }
 
   const { meta = {} } = ao

--- a/lib/ws_servers/api/cancel_order_bitfinex.js
+++ b/lib/ws_servers/api/cancel_order_bitfinex.js
@@ -6,7 +6,7 @@ const {
 } = require('../../util/ws/notify')
 
 module.exports = async (d, ws, bfxClient, symbol, id) => {
-  notifyInfo(ws, 'Cancelling order on Bitfinex')
+  notifyInfo(ws, 'Cancelling order on Bitfinex', ['cancellingOrderOn', { target: 'Bitfinex' }])
 
   try {
     await bfxClient.cancelOrder(id)

--- a/lib/ws_servers/api/handlers/algo_order_params/get.js
+++ b/lib/ws_servers/api/handlers/algo_order_params/get.js
@@ -20,7 +20,7 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   }
 
   const { AlgoOrderParams } = db

--- a/lib/ws_servers/api/handlers/algo_order_params/remove.js
+++ b/lib/ws_servers/api/handlers/algo_order_params/remove.js
@@ -27,7 +27,7 @@ module.exports = async (server, ws, msg) => {
   const { AlgoOrderParams } = db
   try {
     await AlgoOrderParams.rm(id)
-    notifySuccess(ws, 'Algo order parameter has been removed successfully')
+    notifySuccess(ws, 'Algo order parameter has been removed successfully', ['algoOrderParameterRemovedSuccessfully'])
   } catch (e) {
     capture.exception(e)
     notifyInternalError(ws)

--- a/lib/ws_servers/api/handlers/algo_order_params/set.js
+++ b/lib/ws_servers/api/handlers/algo_order_params/set.js
@@ -29,7 +29,7 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   }
 
   const err = validateAOParams(algos, algoID, marketData, params)
@@ -49,6 +49,6 @@ module.exports = async (server, ws, msg) => {
 
   d('Saved algo order parameters %s', id)
 
-  notifySuccess(ws, 'Algo order parameters successfully saved')
+  notifySuccess(ws, 'Algo order parameters successfully saved', ['algoOrderParametersSuccessfullySaved'])
   send(ws, ['data.algo_order_params.saved', id, algoOrderParams])
 }

--- a/lib/ws_servers/api/handlers/on_algo_order_cancel.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_cancel.js
@@ -17,9 +17,9 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   } else if (exID !== 'bitfinex') {
-    return sendError(ws, 'Algo orders currently only enabled for Bitfinex')
+    return sendError(ws, 'Algo orders currently only enabled for Bitfinex', ['algoOrdersCurrentlyOnlyEnabledFor', { target: 'Bitfinex' }])
   }
 
   try {

--- a/lib/ws_servers/api/handlers/on_algo_order_cancel.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_cancel.js
@@ -25,6 +25,6 @@ module.exports = async (server, ws, msg) => {
   try {
     await ws.algoWorker.cancelOrder(gid)
   } catch (e) {
-    return sendError(ws, e.message)
+    return sendError(ws, e.message, e.i18n)
   }
 }

--- a/lib/ws_servers/api/handlers/on_algo_order_load.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_load.js
@@ -40,12 +40,12 @@ module.exports = async (server, ws, msg) => {
       state.active = true
 
       const [, uiData] = await ws.algoWorker.host.loadAO(algoID, gid, state)
-      const { name, label, args } = uiData
+      const { name, label, args, i18n } = uiData
 
       d('AO loaded for user %s [%s]', 'HF_UI', gid)
 
       send(ws, ['algo.order_loaded', gid])
-      send(ws, ['data.ao', 'bitfinex', { gid, name, label, args }])
+      send(ws, ['data.ao', 'bitfinex', { gid, name, label, args, i18n }])
     } catch (e) {
       d('error loading AO %s: %s', algoID, e.stack)
       sendError(ws, `Failed to start algo order: ${algoID}`, ['failedToStartAlgoOrder', { algoID }])

--- a/lib/ws_servers/api/handlers/on_algo_order_load.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_load.js
@@ -22,7 +22,7 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   }
 
   // specific to desktop app
@@ -48,7 +48,7 @@ module.exports = async (server, ws, msg) => {
       send(ws, ['data.ao', 'bitfinex', { gid, name, label, args }])
     } catch (e) {
       d('error loading AO %s: %s', algoID, e.stack)
-      sendError(ws, `Failed to start algo order: ${algoID}`)
+      sendError(ws, `Failed to start algo order: ${algoID}`, ['failedToStartAlgoOrder', { algoID }])
     }
   }
 }

--- a/lib/ws_servers/api/handlers/on_algo_order_remove.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_remove.js
@@ -22,9 +22,9 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   } else if (!ws.clients.bitfinex) {
-    return sendError(ws, 'No client open for Bitfinex')
+    return sendError(ws, 'No client open for Bitfinex', ['noClientOpenFor', { target: 'Bitfinex' }])
   }
 
   const bfxClient = ws.clients.bitfinex
@@ -37,7 +37,7 @@ module.exports = async (server, ws, msg) => {
       const updated = await AlgoOrder.update({ gid, algoID }, { active: false })
       if (updated) removedOrders.push(gid)
     } catch (err) {
-      sendError(ws, `Error removing order: ${algoID} [${gid}]`)
+      sendError(ws, `Error removing order: ${algoID} [${gid}]`, ['errorRemovingOrder', { algoID, gid }])
       d('error removing order %s [%s]: %s', gid, algoID, err.stack)
     }
   }

--- a/lib/ws_servers/api/handlers/on_algo_order_submit.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_submit.js
@@ -22,10 +22,10 @@ module.exports = async (server, ws, msg) => {
 
   if (!isAuthorized(ws, authToken)) {
     sendStatus('failed')
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   } else if (exID !== 'bitfinex') {
     sendStatus('failed')
-    return sendError(ws, 'Algo orders currently only enabled for Bitfinex')
+    return sendError(ws, 'Algo orders currently only enabled for Bitfinex', ['algoOrdersCurrentlyOnlyEnabledFor', { target: 'Bitfinex' }])
   }
 
   try {

--- a/lib/ws_servers/api/handlers/on_algo_order_submit.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_submit.js
@@ -33,6 +33,6 @@ module.exports = async (server, ws, msg) => {
     sendStatus('success')
   } catch (e) {
     sendStatus('failed')
-    return sendError(ws, e.message)
+    return sendError(ws, e.message, e.i18n)
   }
 }

--- a/lib/ws_servers/api/handlers/on_algo_pause.js
+++ b/lib/ws_servers/api/handlers/on_algo_pause.js
@@ -15,7 +15,7 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   }
 
   try {

--- a/lib/ws_servers/api/handlers/on_auth_init.js
+++ b/lib/ws_servers/api/handlers/on_auth_init.js
@@ -15,7 +15,7 @@ const sendAuthenticated = require('../send_authenticated')
 
 module.exports = async (server, ws, msg) => {
   if (ws.authPassword) {
-    return notifyError(ws, 'Already authenticated')
+    return notifyError(ws, 'Already authenticated', ['alreadyAuthenticated'])
   }
 
   const { d, db, marketData, wsURL, restURL } = server
@@ -35,7 +35,8 @@ module.exports = async (server, ws, msg) => {
 
   if (existingCredentials) {
     return notifyError(ws,
-      'Credentials already configured; reset them before re-initializing'
+      'Credentials already configured; reset them before re-initializing',
+      ['credentialsAlreadyConfiguredResetThemBeforeReInitializing']
     )
   }
 

--- a/lib/ws_servers/api/handlers/on_auth_reset.js
+++ b/lib/ws_servers/api/handlers/on_auth_reset.js
@@ -16,6 +16,6 @@ module.exports = async (server, ws, msg) => {
   send(ws, ['info.auth_configured', false])
   send(ws, ['info.auth_token', null])
 
-  notifyInfo(ws, 'Cleared user credentials & data')
+  notifyInfo(ws, 'Cleared user credentials & data', ['clearedUserCredentialsAndData'])
   d('reset user credentials')
 }

--- a/lib/ws_servers/api/handlers/on_auth_submit.js
+++ b/lib/ws_servers/api/handlers/on_auth_submit.js
@@ -12,7 +12,7 @@ const sendAuthenticated = require('../send_authenticated')
 
 module.exports = async (server, ws, msg) => {
   if (ws.authPassword || ws.authControl) {
-    return notifyError(ws, 'Already authenticated')
+    return notifyError(ws, 'Already authenticated', ['alreadyAuthenticated'])
   }
 
   const { d, db, marketData, wsURL, restURL } = server
@@ -34,7 +34,7 @@ module.exports = async (server, ws, msg) => {
     authControl = await verifyPassword(db, hashedPassword)
 
     if (!authControl) {
-      return notifyError(ws, 'Invalid password')
+      return notifyError(ws, 'Invalid password', ['invalidPassword'])
     }
   } catch (e) {
     capture.exception(e)

--- a/lib/ws_servers/api/handlers/on_order_cancel.js
+++ b/lib/ws_servers/api/handlers/on_order_cancel.js
@@ -22,11 +22,11 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   } else if (exID !== 'bitfinex') {
-    return sendError(ws, 'Unrecognised exchange, cannot submit order')
+    return sendError(ws, 'Unrecognised exchange, cannot submit order', ['unrecognisedExchange'])
   } else if (!ws.clients[exID]) {
-    return sendError(ws, `No client open for ${_capitalize(exID)}`)
+    return sendError(ws, `No client open for ${_capitalize(exID)}`, ['noClientOpenFor', { exID }])
   }
 
   switch (exID) {

--- a/lib/ws_servers/api/handlers/on_order_cancel.js
+++ b/lib/ws_servers/api/handlers/on_order_cancel.js
@@ -26,7 +26,7 @@ module.exports = async (server, ws, msg) => {
   } else if (exID !== 'bitfinex') {
     return sendError(ws, 'Unrecognised exchange, cannot submit order', ['unrecognisedExchange'])
   } else if (!ws.clients[exID]) {
-    return sendError(ws, `No client open for ${_capitalize(exID)}`, ['noClientOpenFor', { exID }])
+    return sendError(ws, `No client open for ${_capitalize(exID)}`, ['noClientOpenFor', { target: exID }])
   }
 
   switch (exID) {

--- a/lib/ws_servers/api/handlers/on_order_submit.js
+++ b/lib/ws_servers/api/handlers/on_order_submit.js
@@ -32,7 +32,7 @@ module.exports = async (server, ws, msg) => {
     return sendError(ws, 'Unrecognised exchange, cannot submit order', ['unrecognisedExchange'])
   } else if (!ws.clients[exID]) {
     sendStatus('failed')
-    return sendError(ws, `No client open for ${_capitalize(exID)}`, ['noClientOpenFor', { exID }])
+    return sendError(ws, `No client open for ${_capitalize(exID)}`, ['noClientOpenFor', { target: exID }])
   }
 
   const { userSettings = DEFAULT_SETTINGS } = await UserSettings.getAll()

--- a/lib/ws_servers/api/handlers/on_order_submit.js
+++ b/lib/ws_servers/api/handlers/on_order_submit.js
@@ -26,13 +26,13 @@ module.exports = async (server, ws, msg) => {
 
   if (!isAuthorized(ws, authToken)) {
     sendStatus('failed')
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   } else if (exID !== 'bitfinex') {
     sendStatus('failed')
-    return sendError(ws, 'Unrecognised exchange, cannot submit order')
+    return sendError(ws, 'Unrecognised exchange, cannot submit order', ['unrecognisedExchange'])
   } else if (!ws.clients[exID]) {
     sendStatus('failed')
-    return sendError(ws, `No client open for ${_capitalize(exID)}`)
+    return sendError(ws, `No client open for ${_capitalize(exID)}`, ['noClientOpenFor', { exID }])
   }
 
   const { userSettings = DEFAULT_SETTINGS } = await UserSettings.getAll()
@@ -44,7 +44,7 @@ module.exports = async (server, ws, msg) => {
   packet.meta.aff_code = userSettings.affiliateCode // eslint-disable-line
 
   try {
-    notifyInfo(ws, 'Submitting order to Bitfinex')
+    notifyInfo(ws, 'Submitting order to Bitfinex', ['submittingOrderTo', { target: 'Bitfinex' }])
     await ws.clients.bitfinex.submitOrder(packet)
 
     d('sucessfully submitted order [bitfinex]')

--- a/lib/ws_servers/api/handlers/on_remove_strategy.js
+++ b/lib/ws_servers/api/handlers/on_remove_strategy.js
@@ -20,13 +20,13 @@ module.exports = async (server, ws, msg) => {
   }
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   }
 
   const { Strategy } = db
   try {
     await Strategy.rm(id)
-    notifySuccess(ws, 'The strategy has been removed successfully')
+    notifySuccess(ws, 'The strategy has been removed successfully', ['strategyRemovedSuccessfully'])
   } catch (e) {
     capture.exception(e)
     notifyInternalError(ws)

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -44,7 +44,7 @@ module.exports = async (server, ws, msg) => {
     authControl = await verifyPassword(db, ws.authPassword)
 
     if (!authControl || ws.authControl !== authControl) {
-      return notifyError(ws, 'Invalid password')
+      return notifyError(ws, 'Invalid password', ['invalidPassword'])
     }
   } catch (e) {
     capture.exception(e)
@@ -65,7 +65,7 @@ module.exports = async (server, ws, msg) => {
   d('saved API credentials for Bitfinex')
 
   await validateModes(ws, db, { restURL })
-  notifySuccess(ws, `Encrypted API credentials saved for ${_capitalize(exID)}`)
+  notifySuccess(ws, `Encrypted API credentials saved for ${_capitalize(exID)}`, ['encryptedApiCredentialsSavedFor', { target: _capitalize(exID) }])
   send(ws, ['data.api_credentials.configured', exID])
 
   if (formSent !== mode) {
@@ -96,7 +96,7 @@ module.exports = async (server, ws, msg) => {
   await reconnectAlgoHost(ws)
   Object.values(ws.clients).forEach(ex => ex.reconnect())
 
-  notifySuccess(ws, 'Reconnecting with new credentials...')
+  notifySuccess(ws, 'Reconnecting with new credentials...', ['reconnectingWithNewCredentials'])
 
   if (ws.algoWorker.isStarted) {
     return

--- a/lib/ws_servers/api/handlers/on_save_favourite_trading_pairs.js
+++ b/lib/ws_servers/api/handlers/on_save_favourite_trading_pairs.js
@@ -45,6 +45,6 @@ module.exports = async (server, ws, msg) => {
 
   d(`Favourite trading pairs have been saved (${mode})`)
 
-  notifySuccess(ws, 'Favourite trading pairs successfully saved')
+  notifySuccess(ws, 'Favourite trading pairs successfully saved', ['favouriteTradingPairsSuccessfullySaved'])
   send(ws, ['data.favourite_trading_pairs.saved', pairs])
 }

--- a/lib/ws_servers/api/handlers/on_settings_update.js
+++ b/lib/ws_servers/api/handlers/on_settings_update.js
@@ -46,7 +46,7 @@ module.exports = async (server, ws, msg) => {
 
   ws.UserSettings = settings
 
-  notifySuccess(ws, 'Settings successfully updated')
+  notifySuccess(ws, 'Settings successfully updated', ['settingsSuccessfullyUpdated'])
 
   send(ws, ['data.settings.updated', settings])
 
@@ -61,6 +61,6 @@ module.exports = async (server, ws, msg) => {
 
     await reconnectAlgoHost(ws)
 
-    notifySuccess(ws, 'Reconnecting with new DMS setting...')
+    notifySuccess(ws, 'Reconnecting with new DMS setting...', ['reconnectingWithNewDmsSetting'])
   }
 }

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -13,7 +13,7 @@ const { WS_CONNECTION, DMS_ENABLED } = require('../../constants')
 module.exports = (conf) => {
   const { ws, apiKey, apiSecret, authToken, userSettings, d, opts } = conf
 
-  notifyInfo(ws, 'Connecting to Bitfinex...')
+  notifyInfo(ws, 'Connecting to Bitfinex...', ['connectingTo', { target: 'Bitfinex' }])
 
   const { wsURL, restURL } = opts
   const client = new BitfinexExchangeConnection({ wsURL, restURL })
@@ -33,16 +33,16 @@ module.exports = (conf) => {
   })
 
   client.on('ws2:open', () => {
-    notifyInfo(ws, 'Connected to Bitfinex')
+    notifyInfo(ws, 'Connected to Bitfinex', ['connectedTo', { target: 'Bitfinex' }])
   })
 
   client.on('ws2:event:auth:success', () => {
-    notifySuccess(ws, 'Authenticated with Bitfinex')
+    notifySuccess(ws, 'Authenticated with Bitfinex', ['authenticatedWith', { target: 'Bitfinex' }])
     send(ws, ['data.client', 'bitfinex', WS_CONNECTION.OPENED])
   })
 
   client.on('ws2:close', () => {
-    notifyInfo(ws, 'Disconnected from Bitfinex')
+    notifyInfo(ws, 'Disconnected from Bitfinex', ['disconnectedFrom', { target: 'Bitfinex' }])
     send(ws, ['data.client', 'bitfinex', WS_CONNECTION.CLOSED])
   })
 

--- a/lib/ws_servers/api/send_authenticated.js
+++ b/lib/ws_servers/api/send_authenticated.js
@@ -24,7 +24,7 @@ module.exports = async (ws, db, marketData, d, opts) => {
 
   // Send basic auth data for further requests
   send(ws, ['info.auth_token', authControl])
-  notifySuccess(ws, 'Authenticated')
+  notifySuccess(ws, 'Authenticated', ['authenticated'])
 
   // Grab all exchange API credentials
   const { Credential } = db
@@ -49,7 +49,7 @@ module.exports = async (ws, db, marketData, d, opts) => {
   const { key, secret } = cleartext
 
   ws.bitfinexCredentials = { key, secret }
-  notifySuccess(ws, `Decrypted credentials for bitfinex (${mode})`)
+  notifySuccess(ws, `Decrypted credentials for bitfinex (${mode})`, ['decryptedCredentialsFor', { target: 'Bitfinex', mode }])
   send(ws, ['data.api_credentials.configured', 'bitfinex'])
 
   const { UserSettings } = db

--- a/lib/ws_servers/api/send_settings.js
+++ b/lib/ws_servers/api/send_settings.js
@@ -12,7 +12,7 @@ module.exports = async (server, ws, msg) => {
   const [, authToken] = msg
 
   if (!isAuthorized(ws, authToken)) {
-    return sendError(ws, 'Unauthorized')
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
   }
 
   const defaultSettings = _default

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Add i18n keys and props for `error` and `notify` messages
Format:
`['notify', <type>, <message>, { key: <string>, props: <object>}]` // fourth element is optional
`['error', <message>, { key: <string>, props: <object>}]` // third element is optional

- Add `i18n` property in `data.ao` message
Format: `['data.ao', <type>, <message>, { i18n: { key: <string>, props: <object>} }]` // i18n property is optional

If there is no data for i18n, this means that the message has not yet been translated on our side or it comes from the Bitfinex API

POTENTIAL ISSUE: 
This server [receives messages](https://github.com/bitfinexcom/bfx-hf-server/blob/master/lib/ws_servers/api/open_auth_bitfinex_connection.js#L76-L93) from channel `n` and re-sends them to frontend.
On the one hand, ufx-ui [skips messages of a certain type](https://github.com/bitfinexcom/ufx-ui/blob/d70a04cddcfcbdfa4ad7aeb163be28c541ec5b70/packages/bfx-containers/src/var/config.js#L16-L21), but we can still receive messages of the remaining types.
The [documentation states](https://docs.bitfinex.com/reference#ws-auth-notifications ) that TYPE can be 'on-req', 'oc-req', 'uca', 'fon-req' or 'foc-req'. That is, the UI can still display uca or foc-req notifications and cannot translate them. Also, I can't be sure the documentation is up to date enough.

Based on this, I can only propose to implement the translation of such messages after they are found or to obtain a full list of existing types of messages and their default text