### PR TITLE
AO Params returning additional data from data.algo_order_params endpoint

### DIFF
--- a/lib/ws_servers/api/handlers/algo_order_params/get.js
+++ b/lib/ws_servers/api/handlers/algo_order_params/get.js
@@ -30,5 +30,5 @@ module.exports = async (server, ws, msg) => {
     ['symbol', '=', symbol]
   ])
 
-  send(ws, ['data.algo_order_params', data])
+  send(ws, ['data.algo_order_params', algoID, symbol, data])
 }


### PR DESCRIPTION
Added `algoID` and `symbol` as a return values to `data.algo_order_params`