### PR TITLE
do not enforce auth tokens

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -3,8 +3,6 @@
 const debug = require('debug')
 const d = debug('bfx:hf:server:algo-worker')
 const { AOHost } = require('bfx-hf-algo')
-const PluginBfxAdapter = require('bfx-hf-token-renewal-plugin/lib/adapters/bitfinex-adapter')
-const TokenRenewalPlugin = require('bfx-hf-token-renewal-plugin')
 
 const validateAO = require('./util/validate_ao')
 const { DMS_ENABLED } = require('../../../constants')
@@ -16,8 +14,6 @@ class AlgoWorker {
     this.isStarted = false
     this.tokenPlugin = null
 
-    const { auth: authConfig = {} } = config
-    this.authConfig = authConfig
     this.settings = settings
     this.algoOrders = algoOrders
 
@@ -47,16 +43,9 @@ class AlgoWorker {
       affiliateCode
     )
 
-    if (!authToken) {
-      const adapter = this._createTokenAdapter(apiKey, apiSecret)
-      this.tokenPlugin = new TokenRenewalPlugin(adapter)
-
-      authToken = await this._createAuthToken(adapter)
-
-      plugins.push(this.tokenPlugin)
-    }
-
     const wsSettings = {
+      apiKey,
+      apiSecret,
       authToken,
       dms: dms ? DMS_ENABLED : 0,
       withHeartbeat: true,
@@ -144,11 +133,6 @@ class AlgoWorker {
 
     const adapter = this.host.getAdapter()
     if (!adapter.updateAuthArgs) return
-
-    if (args.apiKey && args.apiSecret) {
-      const adapter = this._createTokenAdapter(args.apiKey, args.apiSecret)
-      args.authToken = await this._createAuthToken(adapter)
-    }
 
     adapter.updateAuthArgs(args)
   }
@@ -325,34 +309,6 @@ class AlgoWorker {
 
       throw new Error('Failed to start algo order')
     }
-  }
-
-  /**
-   * @private
-   * @param {string} apiKey
-   * @param {string} apiSecret
-   * @returns {BitfinexAdapter}
-   */
-  _createTokenAdapter (apiKey, apiSecret) {
-    const { restURL } = this.settings
-
-    return new PluginBfxAdapter({
-      url: restURL,
-      apiKey,
-      apiSecret,
-      ttl: this.authConfig.tokenTtlInSeconds
-    })
-  }
-
-  /**
-   * @private
-   * @param {Object} adapter
-   * @param {function: Promise<{ authToken: string, expiresAt: number }>} adapter.refreshToken
-   * @returns {Promise<string>}
-   */
-  async _createAuthToken (adapter) {
-    const { authToken } = await adapter.refreshToken()
-    return authToken
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "bfx-hf-ext-plugin-dummy": "github:bitfinexcom/bfx-hf-ext-plugin-dummy#v1.0.4",
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git#v2.4.1",
     "bfx-hf-models-adapter-lowdb": "git+https://github.com/bitfinexcom/bfx-hf-models-adapter-lowdb.git#v1.0.5",
-    "bfx-hf-token-renewal-plugin": "git+https://github.com/bitfinexcom/bfx-hf-token-renewal-plugin.git#v1.0.1",
     "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.2.0",
     "bfx-hf-util": "github:bitfinexcom/bfx-hf-util#v1.0.12",
     "bignumber.js": "^9.0.0",

--- a/test/unit/lib/ws_servers/api/algos/algo_worker.js
+++ b/test/unit/lib/ws_servers/api/algos/algo_worker.js
@@ -17,10 +17,6 @@ const AOHostStub = {
   close: sandbox.stub(),
   cleanState: sandbox.stub()
 }
-const TokenAdapterConstructor = sandbox.stub()
-const TokenAdapterStub = {
-  refreshToken: sandbox.stub()
-}
 
 const AlgoWorker = proxyquire('ws_servers/api/algos/algo_worker', {
   'bfx-hf-algo': {
@@ -28,11 +24,7 @@ const AlgoWorker = proxyquire('ws_servers/api/algos/algo_worker', {
       AOHostConstructor(args)
       return AOHostStub
     })
-  },
-  'bfx-hf-token-renewal-plugin/lib/adapters/bitfinex-adapter': sandbox.spy((args) => {
-    TokenAdapterConstructor(args)
-    return TokenAdapterStub
-  })
+  }
 })
 
 describe('AlgoWorker', () => {
@@ -42,7 +34,6 @@ describe('AlgoWorker', () => {
 
   afterEach(() => {
     AOHostConstructor.reset()
-    TokenAdapterConstructor.reset()
     WsStub.reset()
   })
 
@@ -60,7 +51,7 @@ describe('AlgoWorker', () => {
   const config = { auth: { tokenTtlInSeconds: 300 } }
   const apiKey = 'api key'
   const apiSecret = 'api secret'
-  const authToken = 'generated auth token'
+  const authToken = 'auth token'
 
   describe('starting the algo worker', () => {
     const userId = 'user id'
@@ -76,12 +67,11 @@ describe('AlgoWorker', () => {
         }
       }
       AOHostStub.getAOInstances.returns([aoInstance])
-      TokenAdapterStub.refreshToken.returns({ authToken })
 
       const algoWorker = new AlgoWorker(settings, algoOrders, bcast, algoDB, logAlgoOpts, marketData, config)
       expect(algoWorker.isStarted).to.be.false
 
-      await algoWorker.start({ apiKey, apiSecret, userId })
+      await algoWorker.start({ apiKey, apiSecret, authToken, userId })
 
       // generate auth token with api credentials
       // create ao instance
@@ -89,13 +79,15 @@ describe('AlgoWorker', () => {
         aos: [],
         logAlgoOpts: null,
         wsSettings: {
+          apiKey,
+          apiSecret,
           authToken,
           dms: 4,
           withHeartbeat: true,
           affiliateCode: settings.affiliateCode,
           wsURL: settings.wsURL,
           restURL: settings.restURL,
-          plugins: [algoWorker.tokenPlugin]
+          plugins: []
         }
       })
       // register events
@@ -119,64 +111,23 @@ describe('AlgoWorker', () => {
       expect(algoWorker.host).to.eq(AOHostStub)
       algoWorker.close()
     })
-
-    it('should skip auth token generation if the token is already provided', async () => {
-      const aoInstance = {
-        state: {
-          active: true,
-          gid: 'gid',
-          name: 'name',
-          args: 'args',
-          label: 'label'
-        }
-      }
-      AOHostStub.getAOInstances.returns([aoInstance])
-
-      const authToken = 'provided auth token'
-
-      const algoWorker = new AlgoWorker(settings, algoOrders, bcast, algoDB, logAlgoOpts, marketData, config)
-      expect(algoWorker.isStarted).to.be.false
-
-      await algoWorker.start({ authToken, userId })
-
-      assert.notCalled(TokenAdapterConstructor)
-      assert.calledWithExactly(AOHostConstructor, {
-        aos: [],
-        logAlgoOpts: null,
-        wsSettings: {
-          authToken,
-          dms: 4,
-          withHeartbeat: true,
-          affiliateCode: settings.affiliateCode,
-          wsURL: settings.wsURL,
-          restURL: settings.restURL,
-          plugins: []
-        }
-      })
-      algoWorker.close()
-    })
   })
 
-  describe('refresh auth args', () => {
-    it('should create an auth token if api credentials are provided', async () => {
-      TokenAdapterStub.refreshToken.returns({ authToken })
+  it('refresh auth args', async () => {
+    const adapter = { updateAuthArgs: sandbox.stub() }
+    const host = { getAdapter: sandbox.stub().returns(adapter) }
+    const algoWorker = new AlgoWorker(settings, algoOrders, bcast, algoDB, logAlgoOpts, marketData, config)
+    algoWorker.host = host
+    algoWorker.isStarted = true
 
-      const adapter = { updateAuthArgs: sandbox.stub() }
-      const host = { getAdapter: sandbox.stub().returns(adapter) }
-      const algoWorker = new AlgoWorker(settings, algoOrders, bcast, algoDB, logAlgoOpts, marketData, config)
-      algoWorker.host = host
-      algoWorker.isStarted = true
+    const dms = 1
+    await algoWorker.updateAuthArgs({ apiKey, apiSecret, dms })
 
-      const dms = 1
-      await algoWorker.updateAuthArgs({ apiKey, apiSecret, dms })
-
-      assert.calledOnce(host.getAdapter)
-      assert.calledWithExactly(adapter.updateAuthArgs, {
-        apiKey,
-        apiSecret,
-        dms,
-        authToken
-      })
+    assert.calledOnce(host.getAdapter)
+    assert.calledWithExactly(adapter.updateAuthArgs, {
+      apiKey,
+      apiSecret,
+      dms
     })
   })
 


### PR DESCRIPTION
We recently introduced a change to hf-server, which would always prioritize auth tokens over API keys; the code behaves as expected. But it enforces some changes on the user's side, which can lead to some frustrations like:

> certainly, I wish not to allow editing any of the account (personal?) information by HF, what is the real meaning
> certainly, I wish not to allow any wallet transfers by HF. Is this really necessary? If building for a future feature, is there a way to allow the present functions to work without that specific permission?

We can keep using auth tokens for hosted HF and support API keys for the electron app.