### PR TITLE
fix reconnect issue

### DIFF
--- a/lib/exchange_clients/bitfinex/index.js
+++ b/lib/exchange_clients/bitfinex/index.js
@@ -2,6 +2,7 @@
 
 const { Manager, submitOrder, cancelOrder, cancelOrdersByGid } = require('bfx-api-node-core')
 const { RESTv2 } = require('bfx-api-node-rest')
+const Watchdog = require('bfx-api-node-plugin-wd')
 const debug = require('debug')('bfx:hf:server:exchange-clients:bitfinex')
 
 const recvMessage = require('./recv/message')
@@ -57,7 +58,6 @@ class BitfinexExchangeConnection {
   }
 
   openWS (args = {}) {
-    const reconnectDelay = 10 * 1000
     const opts = {
       wsURL: this.wsURL,
       ...args
@@ -65,14 +65,16 @@ class BitfinexExchangeConnection {
 
     this.ws = new Manager({
       ...opts,
-      plugins: [],
+      plugins: [
+        Watchdog({
+          reconnectDelay: 10 * 1000,
+          packetWDDelay: 30 * 1000
+        })
+      ],
       transform: true
     })
     this.ws.on('ws2:message', (msg) => recvMessage(this, msg))
     this.ws.on('ws2:error', this.onWSError.bind(this))
-    this.ws.on('ws2:close', () => {
-      setTimeout(() => this.reconnect(), reconnectDelay)
-    })
   }
 
   openSocket () {

--- a/lib/ws_servers/api/handlers/on_settings_update.js
+++ b/lib/ws_servers/api/handlers/on_settings_update.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { _default } = require('bfx-hf-ui-config').UserSettings
-const { affiliateCode } = _default
+const { _default: DEFAULT_USER_SETTINGS } = require('bfx-hf-ui-config').UserSettings
+const { affiliateCode } = DEFAULT_USER_SETTINGS
 
 const send = require('../../../util/ws/send')
 const sendError = require('../../../util/ws/send_error')
@@ -30,7 +30,7 @@ module.exports = async (server, ws, msg) => {
     return sendError(ws, 'Unauthorized')
   }
 
-  const { userSettings: oldSettings = {} } = await UserSettings.getAll()
+  const { userSettings: oldSettings = DEFAULT_USER_SETTINGS } = await UserSettings.getAll()
   const settings = {
     ga,
     dms,


### PR DESCRIPTION
Issue: 

- https://www.loom.com/share/c8168e797e6b44f99d7ef0ab56d9aa09
- https://www.loom.com/share/a4cf4c47b9f24de1998d9881fb6b51a9

Fix: Calling the reconnect method without usage of watchdog results in removing the socket from the ws pool since watchdog manages a state called `managedClose`. Because of which, close method of websocket is called twice before a connection is established causing this error to be shown.