### PR TITLE
Order update notifications

### DIFF
--- a/lib/util/ws/notify/index.js
+++ b/lib/util/ws/notify/index.js
@@ -5,6 +5,7 @@ const notifyError = require('./error')
 const notifySuccess = require('./success')
 const notifyErrorBitfinex = require('./error_bitfinex')
 const notifyOrderExecuted = require('./order_executed')
+const notifyOrderModified = require('./order_modified')
 const notifyOrderCancelled = require('./order_cancelled')
 const notifyOrderSubmitted = require('./order_submitted')
 const notifyInternalError = require('./internal_error')
@@ -15,6 +16,7 @@ module.exports = {
   notifySuccess,
   notifyErrorBitfinex,
   notifyOrderExecuted,
+  notifyOrderModified,
   notifyOrderCancelled,
   notifyOrderSubmitted,
   notifyInternalError

--- a/lib/util/ws/notify/index.js
+++ b/lib/util/ws/notify/index.js
@@ -7,6 +7,7 @@ const notifyErrorBitfinex = require('./error_bitfinex')
 const notifyOrderExecuted = require('./order_executed')
 const notifyOrderModified = require('./order_modified')
 const notifyOrderCancelled = require('./order_cancelled')
+const notifyOrderPartiallyFilled = require('./order_partially_filled')
 const notifyOrderSubmitted = require('./order_submitted')
 const notifyInternalError = require('./internal_error')
 
@@ -18,6 +19,7 @@ module.exports = {
   notifyOrderExecuted,
   notifyOrderModified,
   notifyOrderCancelled,
+  notifyOrderPartiallyFilled,
   notifyOrderSubmitted,
   notifyInternalError
 }

--- a/lib/util/ws/notify/order_modified.js
+++ b/lib/util/ws/notify/order_modified.js
@@ -2,13 +2,13 @@
 
 const _isFinite = require('lodash/isFinite')
 const _lowerCase = require('lodash/lowerCase')
-const notifyInfo = require('./info')
+const notifySuccess = require('./success')
 const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, originalAmount, price, symbol, type } = order
 
-  notifyInfo(ws, format([
+  notifySuccess(ws, format([
     'Modified', exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
     'order of', Math.abs(+originalAmount), symbol,
     _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],

--- a/lib/util/ws/notify/order_modified.js
+++ b/lib/util/ws/notify/order_modified.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+const _lowerCase = require('lodash/lowerCase')
+const notifyInfo = require('./info')
+const format = require('./util/format')
+
+module.exports = (ws, exID, order) => {
+  const { id, amount, originalAmount, price, symbol, type } = order
+
+  notifyInfo(ws, format([
+    'Modified', exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
+    'order of', Math.abs(+originalAmount), symbol,
+    _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
+    `(ID: ${id})`
+  ]), [
+    `orderModified${originalAmount > 0 ? 'Buy' : 'Sell'}Detailed`, {
+      exID,
+      type,
+      symbol,
+      amount: Math.abs(+originalAmount),
+      price,
+      id
+    }
+  ])
+}

--- a/lib/util/ws/notify/order_modified.js
+++ b/lib/util/ws/notify/order_modified.js
@@ -7,14 +7,15 @@ const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, originalAmount, price, symbol, type } = order
+  const hasPrice = _isFinite(+amount) && _isFinite(+price) && +price > 0
 
   notifySuccess(ws, format([
     'Modified', exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
     'order of', Math.abs(+originalAmount), symbol,
-    _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
+    hasPrice && ['at', price],
     `(ID: ${id})`
   ]), [
-    `orderModified${originalAmount > 0 ? 'Buy' : 'Sell'}Detailed`, {
+    `orderModified${originalAmount > 0 ? 'Buy' : 'Sell'}${hasPrice ? 'At' : ''}Detailed`, {
       exID,
       type,
       symbol,

--- a/lib/util/ws/notify/order_partially_filled.js
+++ b/lib/util/ws/notify/order_partially_filled.js
@@ -2,13 +2,13 @@
 
 const _isFinite = require('lodash/isFinite')
 const _lowerCase = require('lodash/lowerCase')
-const notifyInfo = require('./info')
+const notifySuccess = require('./success')
 const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, originalAmount, price, symbol, type } = order
 
-  notifyInfo(ws, format([
+  notifySuccess(ws, format([
     exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
     'order of', Math.abs(+originalAmount), symbol, 'partially filled',
     _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],

--- a/lib/util/ws/notify/order_partially_filled.js
+++ b/lib/util/ws/notify/order_partially_filled.js
@@ -7,14 +7,15 @@ const format = require('./util/format')
 
 module.exports = (ws, exID, order) => {
   const { id, amount, originalAmount, price, symbol, type } = order
+  const hasPrice = _isFinite(+amount) && _isFinite(+price) && +price > 0
 
   notifySuccess(ws, format([
     exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
     'order of', Math.abs(+originalAmount), symbol, 'partially filled',
-    _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
+    hasPrice && ['at', price],
     `(ID: ${id})`
   ]), [
-    `orderPartiallyFilled${originalAmount > 0 ? 'Buy' : 'Sell'}Detailed`, {
+    `orderPartiallyFilled${originalAmount > 0 ? 'Buy' : 'Sell'}${hasPrice ? 'At' : ''}Detailed`, {
       exID,
       type,
       symbol,

--- a/lib/util/ws/notify/order_partially_filled.js
+++ b/lib/util/ws/notify/order_partially_filled.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+const _lowerCase = require('lodash/lowerCase')
+const notifyInfo = require('./info')
+const format = require('./util/format')
+
+module.exports = (ws, exID, order) => {
+  const { id, amount, originalAmount, price, symbol, type } = order
+
+  notifyInfo(ws, format([
+    exID, _lowerCase(type), originalAmount > 0 ? 'BUY' : 'SELL',
+    'order of', Math.abs(+originalAmount), symbol, 'partially filled',
+    _isFinite(+amount) && _isFinite(+price) && +price > 0 && ['at', price],
+    `(ID: ${id})`
+  ]), [
+    `orderPartiallyFilled${originalAmount > 0 ? 'Buy' : 'Sell'}Detailed`, {
+      exID,
+      type,
+      symbol,
+      amount: Math.abs(+originalAmount),
+      price,
+      id
+    }
+  ])
+}

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -5,7 +5,15 @@ const _isString = require('lodash/isString')
 const _isEmpty = require('lodash/isEmpty')
 const { _default: DEFAULT_SETTINGS } = require('bfx-hf-ui-config').UserSettings
 const BitfinexExchangeConnection = require('../../exchange_clients/bitfinex')
-const { notifyInfo, notifyError, notifySuccess, notifyOrderCancelled, notifyOrderExecuted, notifyOrderSubmitted } = require('../../util/ws/notify')
+const {
+  notifyInfo,
+  notifyError,
+  notifySuccess,
+  notifyOrderCancelled,
+  notifyOrderExecuted,
+  notifyOrderModified,
+  notifyOrderSubmitted
+} = require('../../util/ws/notify')
 const { receiveOrder } = require('../../util/ws/adapters')
 const send = require('../../util/ws/send')
 const { WS_CONNECTION, DMS_ENABLED } = require('../../constants')
@@ -67,7 +75,15 @@ module.exports = (conf) => {
         notifyOrderSubmitted(ws, 'bitfinex', order)
         return send(ws, ['data.order', 'bitfinex', msgData])
       }
-      case 'ou': return send(ws, ['data.order', 'bitfinex', msgData])
+      case 'ou': {
+        const order = receiveOrder(msgData)
+
+        if (order.amount === order.originalAmount) {
+          notifyOrderModified(ws, 'bitfinex', order)
+        }
+
+        return send(ws, ['data.order', 'bitfinex', msgData])
+      }
       case 'oc': {
         const order = receiveOrder(msgData)
 

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -12,6 +12,7 @@ const {
   notifyOrderCancelled,
   notifyOrderExecuted,
   notifyOrderModified,
+  notifyOrderPartiallyFilled,
   notifyOrderSubmitted
 } = require('../../util/ws/notify')
 const { receiveOrder } = require('../../util/ws/adapters')
@@ -80,6 +81,8 @@ module.exports = (conf) => {
 
         if (order.amount === order.originalAmount) {
           notifyOrderModified(ws, 'bitfinex', order)
+        } else if (order.status.startsWith('PARTIALLY')) {
+          notifyOrderPartiallyFilled(ws, 'bitfinex', order)
         }
 
         return send(ws, ['data.order', 'bitfinex', msgData])


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1125859137800433/1201226143620416/f
Dependent task: https://app.asana.com/0/1125859137800433/1201312958023796/f

Changes:
- Added notifications for order updates (e.g, price change or partially filled)

### Required I18N changes:

- Add translation for the keys:
  - `orderModifiedBuyDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_modified.js#L18-L23))
  - `orderModifiedBuyAtDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_modified.js#L18-L23))
  - `orderModifiedSellDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_modified.js#L18-L23))
  - `orderModifiedSellAtDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_modified.js#L18-L23))
  - `orderPartiallyFilledBuyDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_partially_filled.js#L18-L23))
  - `orderPartiallyFilledBuyAtDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_partially_filled.js#L18-L23))
  - `orderPartiallyFilledSellDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_partially_filled.js#L18-L23))
  - `orderPartiallyFilledSellAtDetailed` ([props](https://github.com/bitfinexcom/bfx-hf-server/blob/6d0a8ee3150b56185bf7565f1fa27b175dda9ff4/lib/util/ws/notify/order_partially_filled.js#L18-L23))