### PR TITLE
request all pair configs in a single request

### DIFF
--- a/lib/exchange_clients/bitfinex/get_markets.js
+++ b/lib/exchange_clients/bitfinex/get_markets.js
@@ -8,40 +8,34 @@ const getMaxLevForPairs = require('./util/get_max_lev_for_pairs')
 const getMinMaxSizeForPairs = require('./util/get_min_max_size_for_pairs')
 
 module.exports = async (rest) => {
-  const pairs = rest.conf([
-    'pub:list:pair:exchange',
-    'pub:list:pair:margin',
-    'pub:list:pair:futures'
+  const pairDetails = await rest.conf([
+    'pub:list:pair:exchange', // pairs
+    'pub:list:pair:margin', // pairs
+    'pub:list:pair:futures', // pairs
+    'pub:list:currency:paper', // pairs to exclude
+    'pub:list:currency:viewonly', // pairs to exclude
+    'pub:spec:futures', // lev supported pairs
+    'pub:spec:margin', // lev supported pairs
+    'pub:info:pair', // pairInfo
+    'pub:info:pair:futures' // pairInfo
   ])
 
-  const pairsToExclude = rest.conf([
-    'pub:list:currency:paper',
-    'pub:list:currency:viewonly'
-  ])
+  const allPairs = pairDetails.splice(0, 3)
+  const pairsToExclude = pairDetails.splice(0, 2)
+  const levSupportedPairs = pairDetails.splice(0, 2)
+  const pairInfo = pairDetails
 
-  const levSupportedPairs = rest.conf([
-    'pub:spec:futures',
-    'pub:spec:margin'
-  ])
-
-  const pairInfo = rest.conf([
-    'pub:info:pair',
-    'pub:info:pair:futures'
-  ])
-
-  const [res, pe, lc, pi] = await Promise.all([pairs, pairsToExclude, levSupportedPairs, pairInfo])
-
-  const symbols = _uniq(_flatten(_flatten(res)))
-  const exclude = _flatten(pe)
-  const lp = getMaxLevForPairs(lc)
-  const cp = getMinMaxSizeForPairs(pi)
+  const symbols = _uniq(_flatten(allPairs))
+  const exclude = _flatten(pairsToExclude)
+  const lp = getMaxLevForPairs(levSupportedPairs)
+  const cp = getMinMaxSizeForPairs(pairInfo)
 
   const sf = filterPairs(symbols, exclude, false)
-  const main = sf.map((sym) => symbolTransformer(res, sym, lp, cp, { paper: false }))
+  const main = sf.map((sym) => symbolTransformer(allPairs, sym, lp, cp, { paper: false }))
 
-  const prefilteredPaper = filterPairs(symbols, pe[1], false)
-  const onlyPaperPairs = filterPairs(prefilteredPaper, pe[0], true)
-  const paper = onlyPaperPairs.map((sym) => symbolTransformer(res, sym, lp, cp, { paper: true }))
+  const prefilteredPaper = filterPairs(symbols, pairsToExclude[1], false)
+  const onlyPaperPairs = filterPairs(prefilteredPaper, pairsToExclude[0], true)
+  const paper = onlyPaperPairs.map((sym) => symbolTransformer(allPairs, sym, lp, cp, { paper: true }))
 
   return _flatten([main, paper])
 }


### PR DESCRIPTION
Request all pair configs in a single request instead of multiple parallel requests.