### PR TITLE
Handle strategy execution errors

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
@@ -10,7 +10,7 @@ const parseStrategy = require('bfx-hf-strategy/lib/util/parse_strategy')
 
 module.exports = async (server, ws, msg) => {
   const [
-    , authToken, symbol, tf, includeTrades,
+    , authToken, name, symbol, tf, includeTrades,
     strategyContent, seedCandleCount, margin
   ] = msg
 
@@ -18,7 +18,7 @@ module.exports = async (server, ws, msg) => {
     send(ws, ['strategy.start_live_execution_submit_status', status])
   }
 
-  const err = validateStrategyArgs({ symbol, tf, includeTrades, seedCandleCount, margin })
+  const err = validateStrategyArgs({ name, symbol, tf, includeTrades, seedCandleCount, margin })
   if (err) {
     sendLiveExecutionSubmitStatus(false)
     return sendError(ws, err)
@@ -46,6 +46,7 @@ module.exports = async (server, ws, msg) => {
   try {
     strategy = HFS.define({
       ...strategy,
+      name,
       margin,
       tf,
       symbol,
@@ -73,7 +74,7 @@ module.exports = async (server, ws, msg) => {
     })
   } catch (err) {
     sendLiveExecutionSubmitStatus(false)
-    return sendError(ws, `strategy error: ${err.msg || err.message}`)
+    return sendError(ws, `Strategy error: ${err.msg || err.message}`)
   }
 
   sendLiveExecutionSubmitStatus(true)

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -6,6 +6,7 @@ const { RESTv2 } = require('bfx-api-node-rest')
 const { Manager } = require('bfx-api-node-core')
 const WDPlugin = require('bfx-api-node-plugin-wd')
 const execStrategy = require('bfx-hf-strategy-exec')
+const { apply: applyI18N } = require('../../../../util/i18n')
 const debug = require('debug')('bfx:hf:server:strategy-manager')
 
 class StrategyManager {
@@ -148,6 +149,14 @@ class StrategyManager {
 
   /**
    * @private
+   * @param msg
+   */
+  _sendSuccess (msg, i18n) {
+    this.pub(['notify', 'success', msg, applyI18N(i18n)])
+  }
+
+  /**
+   * @private
    * @param {Error|Object|*} err
    */
   _sendError (err) {
@@ -182,6 +191,12 @@ class StrategyManager {
     await execStrategy(this.strategy, ws2Manager, rest, strategyOpts, this.executeStrategyConn)
 
     this._setActiveStatus(true)
+
+    const { name, symbol, tf } = this.strategy
+    this._sendSuccess(
+      `Started live strategy execution(${name}) for ${symbol}-${tf}`, 
+      ['startedLiveStrategyExecution', { name, symbol, tf }]
+    )
   }
 
   /**
@@ -234,12 +249,14 @@ class StrategyManager {
   /**
    * @public
    */
-  close () {
+   close () {
     this.d('closing ws2 api connection')
-
+    
     if(this.executeStrategyConn){
       this.executeStrategyConn.removeAllListeners()
     }
+    
+    const { name, symbol, tf } = this.strategy
 
     if (this.ws2Manager) {
       this.ws2Manager.closeAllSockets()
@@ -250,6 +267,11 @@ class StrategyManager {
     } else {
       this.d('ws manager not initialized, cannot close sockets')
     }
+    
+    this._sendSuccess(
+      `Stopped live strategy execution(${name}) for ${symbol}-${tf}`, 
+      ['stoppedLiveStrategyExecution', { name, symbol, tf }]
+    )
   }
 }
 

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const EventEmitter = require('events')
 const flatPromise = require('flat-promise')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { Manager } = require('bfx-api-node-core')
@@ -82,9 +83,13 @@ class StrategyManager {
    * @param {object} authResponse - auth response from successful auth
    * @param {object} ws - ws connection
    */
-  _onAuthSuccess (resolve, authResponse, ws) {
+   _onAuthSuccess (resolve, authResponse, ws) {
     this.d('ws2 auth success')
+    
     this.strategy.ws = ws
+    this.executeStrategyConn = new EventEmitter()
+    
+    this._registerStrategyExecutionListeners()
 
     resolve(authResponse)
   }
@@ -98,6 +103,55 @@ class StrategyManager {
     this.d('ws2 auth error: %s', err.msg)
 
     reject(err)
+  }
+
+  /**
+   * @private
+   */
+   _registerStrategyExecutionListeners() {
+    this.executeStrategyConn.on('error', (error) => {
+      const errorMessage = error.text || error
+
+      if (/minimum size/.test(errorMessage)) {
+        return this._handleMinimumSizeError(errorMessage)
+      } else if (/balance/.test(errorMessage)) {
+        return this._handleInsufficientBalanceError(errorMessage)
+      }
+    })
+  }
+
+  /**
+   * @private
+   * @param {Notification|String} err
+   */
+  _handleMinimumSizeError(err) {
+    this.d('received minimum size error: %s', JSON.stringify(err))
+    this.d('stopping strategy execution...')
+    
+    this._sendError(err)
+    
+    this.close()
+  }
+
+  /**
+   * @private
+   * @param {Notification|String} err
+   */
+  _handleInsufficientBalanceError(err) {
+    this.d('received insufficient balance error: %s', JSON.stringify(err))
+    this.d('stopping strategy execution...')
+    
+    this._sendError(err)
+    
+    this.close()
+  }
+
+  /**
+   * @private
+   * @param {Error|Object|*} err
+   */
+  _sendError (err) {
+    this.pub(['notify', 'error', `Strategy Execution Error: ${err}`])
   }
 
   /**
@@ -125,7 +179,7 @@ class StrategyManager {
       ...strategy
     }
 
-    await execStrategy(this.strategy, ws2Manager, rest, strategyOpts)
+    await execStrategy(this.strategy, ws2Manager, rest, strategyOpts, this.executeStrategyConn)
 
     this._setActiveStatus(true)
   }
@@ -183,8 +237,13 @@ class StrategyManager {
   close () {
     this.d('closing ws2 api connection')
 
+    if(this.executeStrategyConn){
+      this.executeStrategyConn.removeAllListeners()
+    }
+
     if (this.ws2Manager) {
       this.ws2Manager.closeAllSockets()
+      this.pub(['strategy.live_execution_status', false, {}])
 
       this._setActiveStatus(false)
       this._clearStrategy()

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -8,7 +8,7 @@ const execStrategy = require('bfx-hf-strategy-exec')
 const debug = require('debug')('bfx:hf:server:strategy-manager')
 
 class StrategyManager {
-  constructor (settings) {
+  constructor (settings, bcast) {
     const { wsURL, restURL } = settings
 
     this.wsURL = wsURL
@@ -20,6 +20,8 @@ class StrategyManager {
     this.strategyArgs = {}
     this.active = false
 
+    this.pub = bcast.ws
+    
     this.rest = new RESTv2({ url: restURL, transform: true })
   }
 

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -23,7 +23,7 @@ class StrategyManager {
     this.active = false
 
     this.pub = bcast.ws
-    
+
     this.rest = new RESTv2({ url: restURL, transform: true })
   }
 
@@ -84,12 +84,12 @@ class StrategyManager {
    * @param {object} authResponse - auth response from successful auth
    * @param {object} ws - ws connection
    */
-   _onAuthSuccess (resolve, authResponse, ws) {
+  _onAuthSuccess (resolve, authResponse, ws) {
     this.d('ws2 auth success')
-    
+
     this.strategy.ws = ws
     this.executeStrategyConn = new EventEmitter()
-    
+
     this._registerStrategyExecutionListeners()
 
     resolve(authResponse)
@@ -109,7 +109,7 @@ class StrategyManager {
   /**
    * @private
    */
-   _registerStrategyExecutionListeners() {
+  _registerStrategyExecutionListeners () {
     this.executeStrategyConn.on('error', (error) => {
       const errorMessage = error.text || error
 
@@ -125,12 +125,12 @@ class StrategyManager {
    * @private
    * @param {Notification|String} err
    */
-  _handleMinimumSizeError(err) {
+  _handleMinimumSizeError (err) {
     this.d('received minimum size error: %s', JSON.stringify(err))
     this.d('stopping strategy execution...')
-    
+
     this._sendError(err)
-    
+
     this.close()
   }
 
@@ -138,12 +138,12 @@ class StrategyManager {
    * @private
    * @param {Notification|String} err
    */
-  _handleInsufficientBalanceError(err) {
+  _handleInsufficientBalanceError (err) {
     this.d('received insufficient balance error: %s', JSON.stringify(err))
     this.d('stopping strategy execution...')
-    
+
     this._sendError(err)
-    
+
     this.close()
   }
 
@@ -194,7 +194,7 @@ class StrategyManager {
 
     const { name, symbol, tf } = this.strategy
     this._sendSuccess(
-      `Started live strategy execution(${name}) for ${symbol}-${tf}`, 
+      `Started live strategy execution(${name}) for ${symbol}-${tf}`,
       ['startedLiveStrategyExecution', { name, symbol, tf }]
     )
   }
@@ -249,13 +249,13 @@ class StrategyManager {
   /**
    * @public
    */
-   close () {
+  close () {
     this.d('closing ws2 api connection')
-    
-    if(this.executeStrategyConn){
+
+    if (this.executeStrategyConn) {
       this.executeStrategyConn.removeAllListeners()
     }
-    
+
     const { name, symbol, tf } = this.strategy
 
     if (this.ws2Manager) {
@@ -267,9 +267,9 @@ class StrategyManager {
     } else {
       this.d('ws manager not initialized, cannot close sockets')
     }
-    
+
     this._sendSuccess(
-      `Stopped live strategy execution(${name}) for ${symbol}-${tf}`, 
+      `Stopped live strategy execution(${name}) for ${symbol}-${tf}`,
       ['stoppedLiveStrategyExecution', { name, symbol, tf }]
     )
   }

--- a/lib/ws_servers/api/handlers/strategy/util/validation.js
+++ b/lib/ws_servers/api/handlers/strategy/util/validation.js
@@ -5,9 +5,11 @@ const _isFinite = require('lodash/isFinite')
 const _isBoolean = require('lodash/isBoolean')
 const { candleWidth } = require('bfx-hf-util')
 
-module.exports = ({ symbol, tf, includeTrades, seedCandleCount, margin }) => {
-  if (!_isString(symbol)) {
-    return 'Symbol not a string'
+module.exports = ({ name, symbol, tf, includeTrades, seedCandleCount, margin }) => {
+  if (!_isString(name)) {
+    return 'Name is not a string'
+  } else if (!_isString(symbol)) {
+    return 'Symbol is not a string'
   } else if (!_isFinite(candleWidth(tf))) {
     return 'Invalid timeframe'
   } else if (!_isBoolean(includeTrades)) {

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -189,7 +189,8 @@ module.exports = class APIWSServer extends WSServer {
     )
 
     ws.strategyManager = new StrategyManager(
-      { dms, wsURL: this.wsURL, restURL: this.restURL }
+      { dms, wsURL: this.wsURL, restURL: this.restURL },
+      { ws: send.bind(send, ws) }
     )
 
     await this.sendInitialConnectionData(ws)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git#v2.4.1",
     "bfx-hf-models-adapter-lowdb": "git+https://github.com/bitfinexcom/bfx-hf-models-adapter-lowdb.git#v1.0.5",
     "bfx-hf-strategy": "git+https://github.com/bitfinexcom/bfx-hf-strategy.git#v1.2.2",
-    "bfx-hf-strategy-exec": "git+https://github.com/bitfinexcom/bfx-hf-strategy-exec.git#v1.1.2",
+    "bfx-hf-strategy-exec": "git+https://github.com/avsek477/bfx-hf-strategy-exec.git#double-every-order-fix",
     "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.2.0",
     "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util#v1.0.12",
     "bignumber.js": "^9.0.0",

--- a/test/unit/lib/ws_servers/api/strategy/manager.js
+++ b/test/unit/lib/ws_servers/api/strategy/manager.js
@@ -7,6 +7,7 @@ const { assert, createSandbox } = require('sinon')
 const proxyquire = require('proxyquire').noCallThru()
 
 const sandbox = createSandbox()
+const WsStub = sandbox.stub()
 const restV2Stub = sandbox.stub()
 const executeStrategyStub = sandbox.stub()
 const ManagerConstructor = sandbox.stub()
@@ -44,6 +45,7 @@ describe('Strategy Manager', () => {
   const apiSecret = 'api secret'
   const authToken = 'auth token'
   const settings = { wsURL, restURL, dms }
+  const bcast = { ws: WsStub }
 
   const ws = { conn: 'connection details' }
   const parsedStrategy = { indicators: 'indicators' }
@@ -55,7 +57,7 @@ describe('Strategy Manager', () => {
 
   describe('#constructor', () => {
     it('creates a new instance', () => {
-      const manager = new StrategyManager(settings)
+      const manager = new StrategyManager(settings, bcast)
 
       expect(manager.active).to.be.false
       expect(manager.ws2Manager).to.be.null
@@ -74,7 +76,7 @@ describe('Strategy Manager', () => {
 
   describe('#start method', async () => {
     it('should call the manager and watchdog plugin with correct arguments', async () => {
-      const manager = new StrategyManager(settings)
+      const manager = new StrategyManager(settings, bcast)
       onceWsStub.withArgs('event:auth:success').yields('auth response', ws)
 
       await manager.start({ apiKey, apiSecret, authToken })
@@ -97,7 +99,7 @@ describe('Strategy Manager', () => {
     })
 
     it('should set the ws object on auth success', async () => {
-      const manager = new StrategyManager(settings)
+      const manager = new StrategyManager(settings, bcast)
       onceWsStub.withArgs('event:auth:success').yields('auth response', ws)
 
       await manager.start({ apiKey, apiSecret, authToken })
@@ -105,7 +107,7 @@ describe('Strategy Manager', () => {
     })
 
     it('should throw error on auth failure', async () => {
-      const manager = new StrategyManager(settings)
+      const manager = new StrategyManager(settings, bcast)
       onceWsStub.withArgs('event:auth:error').yields('auth err response')
       try {
         await manager.start({ apiKey, apiSecret, authToken })
@@ -117,7 +119,7 @@ describe('Strategy Manager', () => {
 
   describe('#execute method', async () => {
     it('should execute strategy and set the status as active', async () => {
-      const manager = new StrategyManager(settings)
+      const manager = new StrategyManager(settings, bcast)
       expect(manager.ws2Manager).to.be.null
       expect(manager.active).to.be.false
 
@@ -142,7 +144,7 @@ describe('Strategy Manager', () => {
 
   describe('#close method', () => {
     it('closes the socket connections, falsifies the active status and clears strategy', async () => {
-      const manager = new StrategyManager(settings)
+      const manager = new StrategyManager(settings, bcast)
       onceWsStub.withArgs('event:auth:success').yields('auth response', ws)
 
       await manager.start({ apiKey, apiSecret, authToken })


### PR DESCRIPTION
- Add notifications for start and stop event of live execution.
- Stop live execution when insufficient balance and minimum order size error is thrown. 
- Add name of strategy for notification purpose.