### PR TITLE
Add algo id in ao events

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -97,8 +97,8 @@ class AlgoWorker {
     const algos = this.getActiveAlgos()
       .map((aoInstance) => {
         const { state = {} } = aoInstance
-        const { gid, name, args, label, createdAt } = state
-        return [gid, name, label, args, createdAt]
+        const { id, gid, name, args, label, createdAt } = state
+        return [id, gid, name, label, args, createdAt]
       })
 
     this.pub(['data.aos', 'bitfinex', algos])
@@ -308,13 +308,13 @@ class AlgoWorker {
     try {
       const [serialized, uiData] = await ao
 
-      const { name, label, args, gid, i18n, createdAt } = uiData
+      const { id, name, label, args, gid, i18n, createdAt } = uiData
       d('ao started: %s %s', name, label)
 
       await this._updateAlgo(serialized)
 
       this.sendSuccess(`Started AO ${name} on Bitfinex`, ['startedAO', { name, target: 'Bitfinex' }])
-      this.pub(['data.ao', 'bitfinex', { gid, name, label, args, i18n, createdAt }])
+      this.pub(['data.ao', 'bitfinex', { id, gid, name, label, args, i18n, createdAt }])
       return gid
     } catch (e) {
       d('error starting AO %s: %s for %s: %s', aoID, e, this.userId, e.stack)

--- a/lib/ws_servers/api/handlers/on_algo_order_load.js
+++ b/lib/ws_servers/api/handlers/on_algo_order_load.js
@@ -37,12 +37,12 @@ module.exports = async (server, ws, msg) => {
       }
 
       const [, uiData] = await ws.algoWorker.host.loadAO(algoID, gid, JSON.parse(state), createdAt)
-      const { name, label, args, i18n } = uiData
+      const { id, name, label, args, i18n } = uiData
 
       d('AO loaded for user %s [%s]', 'HF_UI', gid)
 
       send(ws, ['algo.order_loaded', gid])
-      send(ws, ['data.ao', 'bitfinex', { gid, name, label, args, i18n, createdAt }])
+      send(ws, ['data.ao', 'bitfinex', { id, gid, name, label, args, i18n, createdAt }])
     } catch (e) {
       d('error loading AO %s: %s', algoID, e.stack)
       sendError(ws, `Failed to start algo order: ${algoID}`, ['failedToStartAlgoOrder', { algoID }])

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bfx-api-node-core": "^1.5.5",
     "bfx-api-node-plugin-wd": "^1.0.4",
     "bfx-api-node-rest": "^4.3.1",
-    "bfx-hf-algo": "git+https://github.com/avsek477/bfx-hf-algo.git#add-algo-id-in-ao-events",
+    "bfx-hf-algo": "git+https://github.com/bitfinexcom/bfx-hf-algo.git#v4.8.0",
     "bfx-hf-ext-plugin-dummy": "github:bitfinexcom/bfx-hf-ext-plugin-dummy#v1.0.4",
     "bfx-hf-indicators": "git+https://github.com/bitfinexcom/bfx-hf-indicators.git#v2.1.1",
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git#v2.4.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bfx-api-node-core": "^1.5.5",
     "bfx-api-node-plugin-wd": "^1.0.4",
     "bfx-api-node-rest": "^4.3.1",
-    "bfx-hf-algo": "git+https://github.com/bitfinexcom/bfx-hf-algo.git#v4.7.3",
+    "bfx-hf-algo": "git+https://github.com/avsek477/bfx-hf-algo.git#add-algo-id-in-ao-events",
     "bfx-hf-ext-plugin-dummy": "github:bitfinexcom/bfx-hf-ext-plugin-dummy#v1.0.4",
     "bfx-hf-indicators": "git+https://github.com/bitfinexcom/bfx-hf-indicators.git#v2.1.1",
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git#v2.4.1",

--- a/test/unit/lib/ws_servers/api/algos/algo_worker.js
+++ b/test/unit/lib/ws_servers/api/algos/algo_worker.js
@@ -79,6 +79,7 @@ describe('AlgoWorker', () => {
         state: {
           active: true,
           createdAt: 1633936704466,
+          id: 'id',
           gid: 'gid',
           name: 'name',
           args: 'args',
@@ -120,6 +121,7 @@ describe('AlgoWorker', () => {
       assert.calledWithExactly(WsStub.firstCall, ['opened', userId, 'bitfinex'])
       // send active instances
       assert.calledWithExactly(WsStub.secondCall, ['data.aos', 'bitfinex', [[
+        aoInstance.state.id,
         aoInstance.state.gid,
         aoInstance.state.name,
         aoInstance.state.label,
@@ -201,6 +203,7 @@ describe('AlgoWorker', () => {
       loadAO: sandbox.stub()
     }
     const gid = 'gid'
+    const id = 'id'
     const createdAt = 1633936704466
     const serialized = { gid }
     const uiData = {
@@ -209,7 +212,8 @@ describe('AlgoWorker', () => {
       args: {},
       i18n: {},
       createdAt,
-      gid
+      gid,
+      id
     }
 
     before(() => {


### PR DESCRIPTION
Task: https://app.asana.com/0/1125859137800433/1201518274330299
Depends on: https://github.com/bitfinexcom/bfx-hf-algo/pull/193

data.ao and data.aos events now return algo id in response.

- `data.ao` event response:

```
['data.ao', 'bitfinex', { id, gid, name, label, args, i18n, createdAt }]
```
- `data.aos` event response:
```
['data.aos', 'bitfinex', [[id, gid, name, label, args, createdAt]]]
```