### PR TITLE
Send header flags for orders

### DIFF
--- a/lib/exchange_clients/bitfinex/transformers/order.js
+++ b/lib/exchange_clients/bitfinex/transformers/order.js
@@ -6,19 +6,19 @@ const OrderFlags = {
   REDUCE_ONLY: 2 ** 10 // 1024
 }
 
-const checkHeaderFlags = (flags, meta) => {
+const checkHeaderFlags = (flags, meta, hidden) => {
   return {
     postonly: !!(flags & OrderFlags.POSTONLY),
     oco: !!(flags & OrderFlags.OCO),
     reduceonly: !!(flags & OrderFlags.REDUCE_ONLY),
-    visibleOnHit: !!(meta && meta.make_visible)
+    visibleOnHit: !!(hidden && meta && meta.make_visible)
   }
 }
 
 module.exports = (o = []) => {
   const {
     postonly, oco, reduceonly, visibleOnHit
-  } = checkHeaderFlags(o[12], o[31], o[10]) // flags, meta, mtsTif
+  } = checkHeaderFlags(o[12], o[31], o[24]) // flags, meta, hidden
 
   return [
     o[0], // id

--- a/lib/exchange_clients/bitfinex/transformers/order.js
+++ b/lib/exchange_clients/bitfinex/transformers/order.js
@@ -1,14 +1,44 @@
 'use strict'
 
-module.exports = (o = []) => ([
-  o[0], // id
-  o[1], // gid
-  o[2], // cid
-  o[3], // symbol
-  o[4], // created
-  o[6], // amount
-  o[7], // original amount
-  o[8], // type
-  o[13], // status
-  o[16] // price
-])
+const OrderFlags = {
+  OCO: 2 ** 14, // 16384
+  POSTONLY: 2 ** 12, // 4096
+  REDUCE_ONLY: 2 ** 10 // 1024
+}
+
+const checkHeaderFlags = (flags, meta) => {
+  return {
+    postonly: !!(flags & OrderFlags.POSTONLY),
+    oco: !!(flags & OrderFlags.OCO),
+    reduceonly: !!(flags & OrderFlags.REDUCE_ONLY),
+    visibleOnHit: !!(meta && meta.make_visible)
+  }
+}
+
+module.exports = (o = []) => {
+  const {
+    postonly, oco, reduceonly, visibleOnHit
+  } = checkHeaderFlags(o[12], o[31], o[10]) // flags, meta, mtsTif
+
+  return [
+    o[0], // id
+    o[1], // gid
+    o[2], // cid
+    o[3], // symbol
+    o[4], // created
+    o[6], // amount
+    o[7], // original amount
+    o[8], // type
+    o[10], // mts_tif
+    o[13], // status
+    o[16], // price
+    o[17], // price_avg
+    o[18], // price_trailing
+    o[19], // price_aux_limit
+    Boolean(o[24]), // hidden
+    postonly,
+    oco,
+    reduceonly,
+    visibleOnHit
+  ]
+}

--- a/lib/exchange_clients/bitfinex/transformers/order.js
+++ b/lib/exchange_clients/bitfinex/transformers/order.js
@@ -11,13 +11,14 @@ const checkHeaderFlags = (flags, meta, hidden) => {
     postonly: !!(flags & OrderFlags.POSTONLY),
     oco: !!(flags & OrderFlags.OCO),
     reduceonly: !!(flags & OrderFlags.REDUCE_ONLY),
-    visibleOnHit: !!(hidden && meta && meta.make_visible)
+    visibleOnHit: !!(hidden && meta && meta.make_visible),
+    lev: (meta && meta.lev) || null
   }
 }
 
 module.exports = (o = []) => {
   const {
-    postonly, oco, reduceonly, visibleOnHit
+    postonly, oco, reduceonly, visibleOnHit, lev
   } = checkHeaderFlags(o[12], o[31], o[24]) // flags, meta, hidden
 
   return [
@@ -39,6 +40,7 @@ module.exports = (o = []) => {
     postonly,
     oco,
     reduceonly,
-    visibleOnHit
+    visibleOnHit,
+    lev
   ]
 }

--- a/lib/util/ws/adapters/order.js
+++ b/lib/util/ws/adapters/order.js
@@ -9,6 +9,15 @@ module.exports = (data = []) => ({
   amount: data[5],
   originalAmount: data[6],
   type: data[7],
-  status: data[8],
-  price: data[9]
+  tif: data[8],
+  status: data[9],
+  price: data[10],
+  priceAvg: data[11],
+  priceTrailing: data[12],
+  priceAuxLimit: data[13],
+  hidden: data[14],
+  postonly: data[15],
+  oco: data[16],
+  reduceonly: data[17],
+  visibleOnHit: data[18]
 })


### PR DESCRIPTION
Task: https://app.asana.com/0/1125859137800433/1201518274330304

Return header flags(i.e. postonly, reduceonly, oco, hidden, visibleOnHit) in order details (`data.orders`).

Order detail template: 
```
[
  id,
  gid,
  cid,
  symbol,
  created,
  amount,
  original_amount,
  type,
  mts_tif,
  status,
  price,
  price_avg,
  price_trailing,
  price_aux_limit,
  hidden,
  postonly,
  oco,
  reduceonly,
  visibleOnHit,
  lev
]
```
