### PR TITLE
Generate strategy execution results

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_stop.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_stop.js
@@ -22,7 +22,7 @@ module.exports = async (server, ws, msg) => {
     return sendError(ws, 'No strategy is currently running')
   }
 
-  ws.strategyManager.close()
+  await ws.strategyManager.close()
 
   sendStopLiveExecutionSubmitStatus(true)
 }

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -34,7 +34,7 @@ class StrategyManager {
    * @returns {Promise<void>}
    */
   async start ({ apiKey, apiSecret, authToken }) {
-    const { dms, wsURL } = this.settings
+    const { wsURL } = this.settings
 
     this.ws2Manager = new Manager({
       apiKey,
@@ -42,7 +42,7 @@ class StrategyManager {
       authToken,
       transform: true,
       wsURL,
-      dms,
+      dms: false,
       plugins: [WDPlugin({
         autoReconnect: true, // if false, the connection will only be closed
         reconnectDelay: 5000, // wait 5 seconds before reconnecting

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const EventEmitter = require('events')
 const flatPromise = require('flat-promise')
 const { RESTv2 } = require('bfx-api-node-rest')
 const { Manager } = require('bfx-api-node-core')
 const WDPlugin = require('bfx-api-node-plugin-wd')
-const execStrategy = require('bfx-hf-strategy-exec')
+const LiveStrategyExecution = require('bfx-hf-strategy-exec')
 const { apply: applyI18N } = require('../../../../util/i18n')
 const debug = require('debug')('bfx:hf:server:strategy-manager')
 
@@ -88,9 +87,6 @@ class StrategyManager {
     this.d('ws2 auth success')
 
     this.strategy.ws = ws
-    this.executeStrategyConn = new EventEmitter()
-
-    this._registerStrategyExecutionListeners()
 
     resolve(authResponse)
   }
@@ -110,7 +106,11 @@ class StrategyManager {
    * @private
    */
   _registerStrategyExecutionListeners () {
-    this.executeStrategyConn.on('error', (error) => {
+    if (!this.liveStrategyExecutor) {
+      throw new Error('live strategy executor not initialized')
+    }
+
+    this.liveStrategyExecutor.on('error', (error) => {
       const errorMessage = error.text || error
 
       if (/minimum size/.test(errorMessage)) {
@@ -172,27 +172,36 @@ class StrategyManager {
    * @param {boolean} [strategyArgs.includeTrades] - option to include trades or not
    * @param {number} [strategyArgs.seedCandleCount] - number of candles to seed before strategy execution
    */
-  async execute (strategy = {}, strategyOpts = {}) {
+  async execute (parsedStrategy = {}, strategyOpts = {}) {
     if (!this.strategy.ws) {
       throw new Error('Not authenticated')
     }
 
-    const { ws2Manager, rest, d } = this
-
     this._setStrategyArgs(strategyOpts)
-
-    d('executing strategy')
 
     this.strategy = {
       ...this.strategy,
-      ...strategy
+      ...parsedStrategy
     }
 
-    await execStrategy(this.strategy, ws2Manager, rest, strategyOpts, this.executeStrategyConn)
+    const { ws2Manager, rest, d, strategy } = this
+
+    d('executing strategy')
+
+    this.liveStrategyExecutor = new LiveStrategyExecution({
+      strategy,
+      ws2Manager,
+      rest,
+      strategyOpts
+    })
+
+    this._registerStrategyExecutionListeners()
+
+    await this.liveStrategyExecutor.execute()
 
     this._setActiveStatus(true)
 
-    const { name, symbol, tf } = this.strategy
+    const { name, symbol, tf } = strategy
     this._sendSuccess(
       `Started live strategy execution(${name}) for ${symbol}-${tf}`,
       ['startedLiveStrategyExecution', { name, symbol, tf }]
@@ -249,18 +258,20 @@ class StrategyManager {
   /**
    * @public
    */
-  close () {
+  async close () {
     this.d('closing ws2 api connection')
-
-    if (this.executeStrategyConn) {
-      this.executeStrategyConn.removeAllListeners()
-    }
 
     const { name, symbol, tf } = this.strategy
 
+    if (this.liveStrategyExecutor) {
+      await this.liveStrategyExecutor.stopExecution()
+    }
+
     if (this.ws2Manager) {
       this.ws2Manager.closeAllSockets()
+
       this.pub(['strategy.live_execution_status', false, {}])
+      this.pub(['strategy.live_execution_results', this.liveStrategyExecutor.generateResults()])
 
       this._setActiveStatus(false)
       this._clearStrategy()

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -165,12 +165,12 @@ class StrategyManager {
 
   /**
    * @public
-   * @param {Object} [strategy] - strategy object
-   * @param {Object} [strategyArgs] - strategy options
-   * @param {string} [strategyArgs.symbol] - symbol pair
-   * @param {string} [strategyArgs.tf] - timeframe
-   * @param {boolean} [strategyArgs.includeTrades] - option to include trades or not
-   * @param {number} [strategyArgs.seedCandleCount] - number of candles to seed before strategy execution
+   * @param {Object} [parsedStrategy] - strategy object as created by define() from bfx-hf-strategy
+   * @param {Object} [strategyOpts] - strategy options
+   * @param {string} [strategyOpts.symbol] - symbol pair
+   * @param {string} [strategyOpts.tf] - timeframe
+   * @param {boolean} [strategyOpts.includeTrades] - option to include trades or not
+   * @param {number} [strategyOpts.seedCandleCount] - number of candles to seed before strategy execution
    */
   async execute (parsedStrategy = {}, strategyOpts = {}) {
     if (!this.strategy.ws) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git#v2.4.1",
     "bfx-hf-models-adapter-lowdb": "git+https://github.com/bitfinexcom/bfx-hf-models-adapter-lowdb.git#v1.0.5",
     "bfx-hf-strategy": "git+https://github.com/bitfinexcom/bfx-hf-strategy.git#v1.2.2",
-    "bfx-hf-strategy-exec": "git+https://github.com/bitfinexcom/bfx-hf-strategy-exec.git#v1.1.3",
+    "bfx-hf-strategy-exec": "git+https://github.com/avsek477/bfx-hf-strategy-exec.git#use-class-methods",
     "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.3.0",
     "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util.git#v1.0.12",
     "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bfx-hf-strategy": "git+https://github.com/bitfinexcom/bfx-hf-strategy.git#v1.2.2",
     "bfx-hf-strategy-exec": "git+https://github.com/bitfinexcom/bfx-hf-strategy-exec.git#v1.1.3",
     "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.3.0",
-    "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util#v1.0.12",
+    "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util.git#v1.0.12",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.7.2",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git#v2.4.1",
     "bfx-hf-models-adapter-lowdb": "git+https://github.com/bitfinexcom/bfx-hf-models-adapter-lowdb.git#v1.0.5",
     "bfx-hf-strategy": "git+https://github.com/bitfinexcom/bfx-hf-strategy.git#v1.2.2",
-    "bfx-hf-strategy-exec": "git+https://github.com/avsek477/bfx-hf-strategy-exec.git#use-class-methods",
+    "bfx-hf-strategy-exec": "git+https://github.com/bitfinexcom/bfx-hf-strategy-exec.git#v1.2.0",
     "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.3.0",
     "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util.git#v1.0.12",
     "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bfx-hf-models-adapter-lowdb": "git+https://github.com/bitfinexcom/bfx-hf-models-adapter-lowdb.git#v1.0.5",
     "bfx-hf-strategy": "git+https://github.com/bitfinexcom/bfx-hf-strategy.git#v1.2.2",
     "bfx-hf-strategy-exec": "git+https://github.com/bitfinexcom/bfx-hf-strategy-exec.git#v1.2.0",
-    "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.3.0",
+    "bfx-hf-ui-config": "github:bitfinexcom/bfx-hf-ui-config#v1.4.0",
     "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util.git#v1.0.12",
     "bignumber.js": "^9.0.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
Depends on: https://github.com/bitfinexcom/bfx-hf-strategy-exec/pull/17
Task: https://app.asana.com/0/1125859137800433/1201692861364568

Generate results when strategy execution is stopped.

Response Event: 
```
["strategy.live_execution_results", {
  avgPL: -0.013928354893999823, // Average Profit/Loss (in $)
  candles: [], // candle data received from api; useful for plotting graphs in result
  fees: 0.102195263152, // Fees (in $)
  maxPL: 0, // Maximum profit/loss during the strategy execution (in $)
  minPL: -0.03495079999999941, // Minimum profit/loss during the strategy execution (in $)
  nCandles: 173, // Number of candles data received
  nGains: 0, // Number of profit trades made
  nLosses: 4, // Number of loss trades made
  nOpens: 4, // Positions count
  nStrategyTrades: 8, // Total number of trades made during strategy execution
  nTrades: 0, // Number of trades data received from api
  pf: 0, // Profit Factor 
  pl: -0.11142683915199858,  // Total Profil/Loss (in $)
  stdDeviation: 0.015339910718107074, // Volatility
  strategy: {
    trades: [] // trades placed via strategy executor
  },
  trades: [], // trades data received from api
  vol: 51.097631576 // Trade volume (in $)
}]
```