### PR TITLE
fix postonly order flag

### DIFF
--- a/lib/exchange_clients/bitfinex/transformers/order.js
+++ b/lib/exchange_clients/bitfinex/transformers/order.js
@@ -2,13 +2,12 @@
 
 const OrderFlags = {
   OCO: 2 ** 14, // 16384
-  POSTONLY: 2 ** 12, // 4096
   REDUCE_ONLY: 2 ** 10 // 1024
 }
 
 const checkHeaderFlags = (flags, meta, hidden) => {
   return {
-    postonly: !!(flags & OrderFlags.POSTONLY),
+    postonly: Boolean(meta && meta['$F7']),
     oco: !!(flags & OrderFlags.OCO),
     reduceonly: !!(flags & OrderFlags.REDUCE_ONLY),
     visibleOnHit: !!(hidden && meta && meta.make_visible),


### PR DESCRIPTION
Checks the meta parameter for finding the post-only flag.

Slack conversation: https://bitfinex.slack.com/archives/C0289JPRZ3Q/p1644520233230309