### PR TITLE
expose algo orders list

### DIFF
--- a/lib/algo_orders.js
+++ b/lib/algo_orders.js
@@ -1,0 +1,17 @@
+const {
+  Iceberg,
+  TWAP,
+  AccumulateDistribute,
+  PingPong,
+  MACrossover,
+  OCOCO
+} = require('bfx-hf-algo')
+
+module.exports = {
+  Iceberg,
+  TWAP,
+  AccumulateDistribute,
+  PingPong,
+  MACrossover,
+  OCOCO
+}


### PR DESCRIPTION
The entry point for hf-algo module exposes the list of algo orders and other things like the host and the async event emitter. It is better to centralize the correct list for AOs **only**.