### PR TITLE
add order history endpoint

### DIFF
--- a/lib/ws_servers/api/handlers/on_order_history_request.js
+++ b/lib/ws_servers/api/handlers/on_order_history_request.js
@@ -32,11 +32,11 @@ const orderHistoryOptsValidator = ({ authToken, start, end, limit, symbol }) => 
     return 'invalid authToken'
   } else if (symbol && !_isString(symbol)) {
     return 'invalid symbol'
-  } else if (!_isInteger(start)) {
+  } else if (start && !_isInteger(start)) {
     return 'invalid start timestamp'
-  } else if (!_isInteger(end)) {
+  } else if (end && !_isInteger(end)) {
     return 'invalid end timestamp'
-  } else if (!_isInteger(limit)) {
+  } else if (limit && !_isInteger(limit)) {
     return 'invalid limit'
   }
 
@@ -47,7 +47,7 @@ module.exports = async (server, ws, msg) => {
   const { restURL, d } = server
   const { bitfinexCredentials = {} } = ws
   const { key: apiKey, secret: apiSecret } = bitfinexCredentials
-  const [, authToken, start, end, limit, symbol = null] = msg
+  const [, authToken, start = null, end = null, limit = 500, symbol = null] = msg
 
   const err = orderHistoryOptsValidator({ authToken, start, end, limit, symbol })
 

--- a/lib/ws_servers/api/handlers/on_order_history_request.js
+++ b/lib/ws_servers/api/handlers/on_order_history_request.js
@@ -4,12 +4,44 @@ const { RESTv2 } = require('bfx-api-node-rest')
 
 const _omit = require('lodash/omit')
 const _isString = require('lodash/isString')
+const _isFinite = require('lodash/isFinite')
 const send = require('../../../util/ws/send')
 const sendError = require('../../../util/ws/send_error')
 const isAuthorized = require('../../../util/ws/is_authorized')
-const validateParams = require('../../../util/ws/validate_params')
 
 const omitFields = ['_apiInterface', '_boolFields', '_events', '_eventsCount', '_fields']
+
+const filterOrdersByScope = (orders = [], scope = 'app') => {
+  return orders
+    .filter((order) => {
+      if (!order.meta) {
+        return false
+      }
+
+      if (scope === 'app') {
+        return order.meta.scope === scope || order.meta._HF
+      }
+
+      return order.meta.scope === scope
+    })
+    .map(hist => _omit(hist, omitFields))
+}
+
+const orderHistoryOptsValidator = ({ authToken, start, end, limit, symbol }) => {
+  if (authToken && !_isString(authToken)) {
+    return 'invalid authToken'
+  } else if (symbol && !_isString(symbol)) {
+    return 'invalid symbol'
+  } else if (!_isFinite(start)) {
+    return 'invalid start timestamp'
+  } else if (!_isFinite(end)) {
+    return 'invalid end timestamp'
+  } else if (!_isFinite(limit)) {
+    return 'invalid limit'
+  }
+
+  return null
+}
 
 module.exports = async (server, ws, msg) => {
   const { restURL, d } = server
@@ -17,16 +49,11 @@ module.exports = async (server, ws, msg) => {
   const { key: apiKey, secret: apiSecret } = bitfinexCredentials
   const [, authToken, start, end, limit, symbol = null] = msg
 
-  const validRequest = validateParams(ws, {
-    authToken: { type: 'string', v: authToken },
-    start: { type: 'number', v: start },
-    end: { type: 'number', v: end },
-    limit: { type: 'number', v: limit }
-  })
+  const err = orderHistoryOptsValidator({ authToken, start, end, limit, symbol })
 
-  if (!validRequest || (symbol && !_isString(symbol))) {
+  if (err) {
     d('invalid request: order_history_request')
-    return
+    return sendError(ws, err)
   }
 
   if (!isAuthorized(ws, authToken)) {
@@ -44,8 +71,9 @@ module.exports = async (server, ws, msg) => {
 
   send(ws, [
     'data.order_history',
-    orders
-      .filter(hist => hist.meta && (hist.meta.scope === 'app' || hist.meta._HF))
-      .map(hist => _omit(hist, omitFields))
+    filterOrdersByScope(orders)
   ])
 }
+
+module.exports.filterOrdersByScope = filterOrdersByScope
+module.exports.orderHistoryOptsValidator = orderHistoryOptsValidator

--- a/lib/ws_servers/api/handlers/on_order_history_request.js
+++ b/lib/ws_servers/api/handlers/on_order_history_request.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { RESTv2 } = require('bfx-api-node-rest')
+
+const _omit = require('lodash/omit')
+const _isString = require('lodash/isString')
+const send = require('../../../util/ws/send')
+const sendError = require('../../../util/ws/send_error')
+const isAuthorized = require('../../../util/ws/is_authorized')
+const validateParams = require('../../../util/ws/validate_params')
+
+const omitFields = ['_apiInterface', '_boolFields', '_events', '_eventsCount', '_fields']
+
+module.exports = async (server, ws, msg) => {
+  const { restURL, d } = server
+  const { bitfinexCredentials = {} } = ws
+  const { key: apiKey, secret: apiSecret } = bitfinexCredentials
+  const [, authToken, start, end, limit, symbol = null] = msg
+
+  const validRequest = validateParams(ws, {
+    authToken: { type: 'string', v: authToken },
+    start: { type: 'number', v: start },
+    end: { type: 'number', v: end },
+    limit: { type: 'number', v: limit }
+  })
+
+  if (!validRequest || (symbol && !_isString(symbol))) {
+    d('invalid request: order_history_request')
+    return
+  }
+
+  if (!isAuthorized(ws, authToken)) {
+    return sendError(ws, 'Unauthorized', ['unauthorized'])
+  }
+
+  const rest = new RESTv2({
+    transform: true,
+    url: restURL,
+    apiKey: apiKey,
+    apiSecret: apiSecret
+  })
+
+  const orders = await rest.orderHistory(symbol, start, end, limit)
+
+  send(ws, [
+    'data.order_history',
+    orders
+      .filter(hist => hist.meta && (hist.meta.scope === 'app' || hist.meta._HF))
+      .map(hist => _omit(hist, omitFields))
+  ])
+}

--- a/lib/ws_servers/api/handlers/on_order_history_request.js
+++ b/lib/ws_servers/api/handlers/on_order_history_request.js
@@ -4,7 +4,7 @@ const { RESTv2 } = require('bfx-api-node-rest')
 
 const _omit = require('lodash/omit')
 const _isString = require('lodash/isString')
-const _isFinite = require('lodash/isFinite')
+const _isInteger = require('lodash/isInteger')
 const send = require('../../../util/ws/send')
 const sendError = require('../../../util/ws/send_error')
 const isAuthorized = require('../../../util/ws/is_authorized')
@@ -32,11 +32,11 @@ const orderHistoryOptsValidator = ({ authToken, start, end, limit, symbol }) => 
     return 'invalid authToken'
   } else if (symbol && !_isString(symbol)) {
     return 'invalid symbol'
-  } else if (!_isFinite(start)) {
+  } else if (!_isInteger(start)) {
     return 'invalid start timestamp'
-  } else if (!_isFinite(end)) {
+  } else if (!_isInteger(end)) {
     return 'invalid end timestamp'
-  } else if (!_isFinite(limit)) {
+  } else if (!_isInteger(limit)) {
     return 'invalid limit'
   }
 

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -24,6 +24,7 @@ const onAlgoPause = require('./handlers/on_algo_pause')
 const onSettingsUpdate = require('./handlers/on_settings_update')
 const onSettingsRequest = require('./send_settings')
 const onCoreSettingsRequest = require('./handlers/on_core_settings_request')
+const onOrderHistoryRequest = require('./handlers/on_order_history_request')
 
 const onSaveFavouriteTradingPairs = require('./handlers/on_save_favourite_trading_pairs')
 const onFavouriteTradingPairsRequest = require('./handlers/on_favourite_trading_pairs_request')
@@ -74,6 +75,7 @@ module.exports = class APIWSServer extends WSServer {
         'get.active_algo_orders': onActiveAlgoOrdersRequest,
         'get.favourite_trading_pairs': onFavouriteTradingPairsRequest,
         'get.show_algo_pause_info': onShowAlgoPauseInfoRequest,
+        'get.order_history': onOrderHistoryRequest,
 
         'algo_order_params.save': onAlgoOrderParamsSave,
         'algo_order_params.get': onAlgoOrderParamsRequest,


### PR DESCRIPTION
Task: https://app.asana.com/0/1201848935859401/1202061744347139

Fetches order history based on the inputs provided.

Client request: 
```
WSActions.send([
    'get.order_history',
    authToken,
    start, // number, required 
    end, // number, required
    limit, // number, required
    symbol // string, optional
  ])
```

Reponse: 
```
['data.order_history', orders]
```