### PR TITLE
Add strategy type

### DIFF
--- a/lib/util/decrypt_strategy.js
+++ b/lib/util/decrypt_strategy.js
@@ -5,7 +5,7 @@ const genAESKey = require('./gen_aes_key')
 
 module.exports = async (strategy, password) => {
   const {
-    id, label, savedTs, strategyType, cryptedLabel, defineIndicators, onPriceUpdate, onEnter, onUpdate,
+    id, label, savedTs, strategyType = null, cryptedLabel, defineIndicators, onPriceUpdate, onEnter, onUpdate,
     onUpdateLong, onUpdateShort, onUpdateClosing, onPositionOpen,
     onPositionUpdate, onPositionClose, onStart, onStop
   } = strategy

--- a/lib/util/decrypt_strategy.js
+++ b/lib/util/decrypt_strategy.js
@@ -5,7 +5,7 @@ const genAESKey = require('./gen_aes_key')
 
 module.exports = async (strategy, password) => {
   const {
-    id, label, savedTs, cryptedLabel, defineIndicators, onPriceUpdate, onEnter, onUpdate,
+    id, label, savedTs, strategyType, cryptedLabel, defineIndicators, onPriceUpdate, onEnter, onUpdate,
     onUpdateLong, onUpdateShort, onUpdateClosing, onPositionOpen,
     onPositionUpdate, onPositionClose, onStart, onStop
   } = strategy
@@ -36,6 +36,7 @@ module.exports = async (strategy, password) => {
     id,
     label,
     savedTs,
+    strategyType,
     defineIndicators: decryptedDefineIndicators,
     onPriceUpdate: decryptedOnPriceUpdate,
     onEnter: decryptedOnEnter,

--- a/lib/util/encrypt_strategy.js
+++ b/lib/util/encrypt_strategy.js
@@ -5,7 +5,7 @@ const genAESKey = require('./gen_aes_key')
 
 module.exports = async (strategy, password) => {
   const {
-    id, label, savedTs, strategyType, defineIndicators, onPriceUpdate, onEnter, onUpdate, onUpdateLong,
+    id, label, savedTs, strategyType = null, defineIndicators, onPriceUpdate, onEnter, onUpdate, onUpdateLong,
     onUpdateShort, onUpdateClosing, onPositionOpen, onPositionUpdate,
     onPositionClose, onStart, onStop
   } = strategy

--- a/lib/util/encrypt_strategy.js
+++ b/lib/util/encrypt_strategy.js
@@ -5,7 +5,7 @@ const genAESKey = require('./gen_aes_key')
 
 module.exports = async (strategy, password) => {
   const {
-    id, label, savedTs, defineIndicators, onPriceUpdate, onEnter, onUpdate, onUpdateLong,
+    id, label, savedTs, strategyType, defineIndicators, onPriceUpdate, onEnter, onUpdate, onUpdateLong,
     onUpdateShort, onUpdateClosing, onPositionOpen, onPositionUpdate,
     onPositionClose, onStart, onStop
   } = strategy
@@ -45,6 +45,7 @@ module.exports = async (strategy, password) => {
     id,
     label,
     savedTs,
+    strategyType,
     cryptedLabel: labelCipherText,
 
     defineIndicators: defineIndicatorsCipherText,


### PR DESCRIPTION
Depends on: https://github.com/bitfinexcom/bfx-hf-models/pull/25

Add strategy type property for strategies.

Returns `strategyType` as `null` for old strategies/non-selected types.