### PR TITLE
remove git hook

### DIFF
--- a/dev/hooks/pre-push
+++ b/dev/hooks/pre-push
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-npm run test

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ws": "^8.2.1"
   },
   "scripts": {
-    "preinstall": "git config core.hooksPath dev/hooks",
     "start": "NODE_PATH=lib node examples/server.js",
     "lint": "standard",
     "coverage": "nyc --all --reporter lcov npm run unit",


### PR DESCRIPTION
Git hooks are causing issues for npm to install server as a dependency, I'll remove it for now.
This is going to be replaced by a GitHub action later on.