### PR TITLE
Close on error

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
@@ -88,5 +88,6 @@ module.exports = async (server, ws, msg) => {
   } catch (err) {
     sendLiveExecutionSubmitStatus(false, gid)
     sendError(ws, `Strategy error: ${err.msg || err.message}`)
+    ws.strategyManager.close(gid)
   }
 }

--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
@@ -14,8 +14,8 @@ module.exports = async (server, ws, msg) => {
     strategyContent, seedCandleCount, margin, constraints = {}
   ] = msg
 
-  const sendLiveExecutionSubmitStatus = (status) => {
-    send(ws, ['strategy.start_live_execution_submit_status', status])
+  const sendLiveExecutionSubmitStatus = (status, gid = null) => {
+    send(ws, ['strategy.start_live_execution_submit_status', status, gid])
   }
 
   const err = validateStrategyArgs({
@@ -66,9 +66,13 @@ module.exports = async (server, ws, msg) => {
     return sendError(ws, 'Strategy is invalid')
   }
 
+  const { gid } = strategy
   const { key, secret } = ws.bitfinexCredentials
+
   try {
     await ws.strategyManager.start({ apiKey: key, apiSecret: secret })
+
+    sendLiveExecutionSubmitStatus(true, gid)
 
     // execute strategy
     await ws.strategyManager.execute(strategy, {
@@ -82,9 +86,7 @@ module.exports = async (server, ws, msg) => {
       ...constraints
     })
   } catch (err) {
-    sendLiveExecutionSubmitStatus(false)
-    return sendError(ws, `Strategy error: ${err.msg || err.message}`)
+    sendLiveExecutionSubmitStatus(false, gid)
+    sendError(ws, `Strategy error: ${err.msg || err.message}`)
   }
-
-  sendLiveExecutionSubmitStatus(true)
 }

--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
@@ -88,6 +88,6 @@ module.exports = async (server, ws, msg) => {
   } catch (err) {
     sendLiveExecutionSubmitStatus(false, gid)
     sendError(ws, `Strategy error: ${err.msg || err.message}`)
-    ws.strategyManager.close(gid)
+    await ws.strategyManager.close(gid)
   }
 }

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const uuid = require('uuid/v4')
 const _pick = require('lodash/pick')
 const _omit = require('lodash/omit')
 const _isEqual = require('lodash/isEqual')
@@ -252,8 +251,8 @@ class StrategyManager {
       throw new Error('Not authenticated')
     }
 
-    const strategyMapKey = uuid()
     const { ws2Manager, rest, d, ws } = this
+    const { gid } = parsedStrategy
     const { allocation, maxPositionSize } = strategyOpts
 
     const priceFeed = new PriceFeed()
@@ -271,7 +270,7 @@ class StrategyManager {
 
     this.performanceWatchers = startPerformanceWatchers(
       perfManager,
-      this._abortStrategy.bind(this, strategyMapKey),
+      this._abortStrategy.bind(this, gid),
       strategyOpts
     )
 
@@ -286,12 +285,12 @@ class StrategyManager {
       perfManager
     })
 
-    this._registerStrategyExecutionListeners(liveStrategyExecutor, strategyMapKey, strategyOpts)
+    this._registerStrategyExecutionListeners(liveStrategyExecutor, gid, strategyOpts)
 
     await liveStrategyExecutor.execute()
 
     const startedOn = Date.now()
-    this.strategy.set(strategyMapKey, {
+    this.strategy.set(gid, {
       strategy,
       strategyOpts,
       liveStrategyExecutor,
@@ -308,7 +307,7 @@ class StrategyManager {
       ['startedLiveStrategyExecution', { label, symbol, tf }]
     )
 
-    this.pub(['strategy.live_execution_started', strategyMapKey, { ...strategyOpts, startedOn }])
+    this.pub(['strategy.live_execution_started', gid, { ...strategyOpts, startedOn }])
     this._sendLiveExecutionStatus()
   }
 

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -83,10 +83,6 @@ class StrategyManager {
     await this._connect()
   }
 
-  /**
-   * @private
-   * @returns {Promise<AuthResponse>}
-   */
   async _connect () {
     this.d('connecting to ws2 API')
     const { promise: onConnected, resolve, reject } = flatPromise()
@@ -109,7 +105,7 @@ class StrategyManager {
 
   /**
    * @private
-   * @param {object} resolve - resolve promise
+   * @param {function} resolve - resolve promise
    * @param {object} authResponse - auth response from successful auth
    * @param {object} ws - ws connection
    */
@@ -123,8 +119,8 @@ class StrategyManager {
 
   /**
    * @private
-   * @param {object} reject - reject promise
-   * @param {Error} error - error from incoming event
+   * @param {function} reject - reject promise
+   * @param {Error} err - error from incoming event
    */
   _onAuthError (reject, err) {
     this.d('ws2 auth error: %s', err.msg)
@@ -162,6 +158,8 @@ class StrategyManager {
   /**
    * @private
    * @param {Notification|String} err
+   * @param strategyMapKey
+   * @param strategyOpts
    */
   _handleMinimumSizeError (err, strategyMapKey, strategyOpts) {
     this.d('received minimum size error [for %s]: %s', strategyMapKey, JSON.stringify(err))
@@ -175,6 +173,8 @@ class StrategyManager {
   /**
    * @private
    * @param {Notification|String} err
+   * @param strategyMapKey
+   * @param strategyOpts
    */
   _handleInsufficientBalanceError (err, strategyMapKey, strategyOpts) {
     this.d('received insufficient balance error [for %s]: %s', strategyMapKey, JSON.stringify(err))
@@ -197,6 +197,7 @@ class StrategyManager {
   /**
    * @private
    * @param msg
+   * @param i18n
    */
   _sendSuccess (msg, i18n) {
     this.pub(['notify', 'success', msg, applyI18N(i18n)])
@@ -205,6 +206,8 @@ class StrategyManager {
   /**
    * @private
    * @param {Error|Object|*} err
+   * @param strategyMapKey
+   * @param label
    */
   _sendError (err, strategyMapKey, { label }) {
     this.pub(['notify', 'error', `Strategy Execution Error[${label}(${strategyMapKey})]: ${err}`])
@@ -378,9 +381,7 @@ class StrategyManager {
         return this.d('error unsubscribing: unknown %s channel [%o]', unsubscriptionChannel, filter)
       }
 
-      const nextSocket = unsubscribe(socket, chanId)
-
-      return nextSocket
+      return unsubscribe(socket, chanId)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",

--- a/test/unit/lib/ws_servers/api/strategy/manager.js
+++ b/test/unit/lib/ws_servers/api/strategy/manager.js
@@ -226,8 +226,8 @@ describe('Strategy Manager', () => {
       sandbox.stub(manager, '_unsubscribe')
 
       await manager.start({ apiKey, apiSecret, authToken })
-      await manager.execute(parsedStrategy, strategyOpts)
-      await manager.execute(parsedStrategy, strategyOpts)
+      await manager.execute({ ...parsedStrategy, gid: 1 }, strategyOpts)
+      await manager.execute({ ...parsedStrategy, gid: 2 }, strategyOpts)
 
       const strategyMapKeys = manager.strategy.keys()
       await manager.close(strategyMapKeys.next().value)
@@ -266,8 +266,8 @@ describe('Strategy Manager', () => {
       sandbox.stub(manager, '_unsubscribe')
 
       await manager.start({ apiKey, apiSecret, authToken })
-      await manager.execute(parsedStrategy, { ...strategyOpts, includeTrades: true })
-      await manager.execute(parsedStrategy, { ...strategyOpts, includeTrades: true })
+      await manager.execute({ ...parsedStrategy, gid: 1 }, { ...strategyOpts, includeTrades: true })
+      await manager.execute({ ...parsedStrategy, gid: 2 }, { ...strategyOpts, includeTrades: true })
 
       const strategyMapKeys = manager.strategy.keys()
       await manager.close(strategyMapKeys.next().value)
@@ -308,8 +308,8 @@ describe('Strategy Manager', () => {
       sandbox.stub(manager, '_unsubscribe')
 
       await manager.start({ apiKey, apiSecret, authToken })
-      await manager.execute(parsedStrategy, { ...strategyOpts, includeTrades: true })
-      await manager.execute(parsedStrategy, strategyOpts)
+      await manager.execute({ ...parsedStrategy, gid: 1 }, { ...strategyOpts, includeTrades: true })
+      await manager.execute({ ...parsedStrategy, gid: 2 }, strategyOpts)
 
       const strategyMapKeys = manager.strategy.keys()
       await manager.close(strategyMapKeys.next().value)
@@ -325,9 +325,9 @@ describe('Strategy Manager', () => {
 
       sandbox.stub(manager, 'close')
       await manager.start({ apiKey, apiSecret, authToken })
-      await manager.execute(parsedStrategy, strategyOpts)
-      await manager.execute(parsedStrategy, strategyOpts)
-      await manager.execute(parsedStrategy, strategyOpts)
+      await manager.execute({ ...parsedStrategy, gid: 1 }, strategyOpts)
+      await manager.execute({ ...parsedStrategy, gid: 2 }, strategyOpts)
+      await manager.execute({ ...parsedStrategy, gid: 3 }, strategyOpts)
 
       await manager.stopAllActiveStrategies()
 


### PR DESCRIPTION
* return the strategy gid earlier so the UI has the possibility to cancel it
* close strategy when an error is thrown

related to: https://app.asana.com/0/0/1202360682127845/1202404281380706/f
and: https://app.asana.com/0/home/1200227858407188/1202407198167962/f

### API changes
The `['strategy.start_live_execution_submit_status', status, gid]` will now send the gid as last arg when the status is true