### PR TITLE
add strategyId and strategyType for input parameters

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
@@ -10,8 +10,8 @@ const parseStrategy = require('bfx-hf-strategy/lib/util/parse_strategy')
 
 module.exports = async (server, ws, msg) => {
   const [
-    , authToken, label, symbol, timeframe, trades,
-    strategyContent, candleSeed, margin, constraints = {}
+    , authToken, strategyId, label, symbol, timeframe, trades,
+    strategyContent, strategyType, candleSeed, margin, constraints = {}
   ] = msg
 
   const sendLiveExecutionSubmitStatus = (status, strategyMapKey = null) => {
@@ -19,12 +19,14 @@ module.exports = async (server, ws, msg) => {
   }
 
   const err = validateStrategyArgs({
+    strategyId,
     label,
     symbol,
     timeframe,
     trades,
     candleSeed,
     margin,
+    strategyType,
     ...constraints
   })
   if (err) {
@@ -67,8 +69,6 @@ module.exports = async (server, ws, msg) => {
   }
 
   const { id: strategyMapKey } = strategy
-  const { id: strategyId, strategyOptions = {} } = strategyContent
-  const { strategyType } = strategyOptions
   const { key, secret } = ws.bitfinexCredentials
 
   try {

--- a/lib/ws_servers/api/handlers/strategy/util/validation.js
+++ b/lib/ws_servers/api/handlers/strategy/util/validation.js
@@ -1,22 +1,29 @@
 'use strict'
 
+const _isNil = require('lodash/isNil')
 const _isString = require('lodash/isString')
 const _isFinite = require('lodash/isFinite')
 const _isBoolean = require('lodash/isBoolean')
+const _isPlainObject = require('lodash/isPlainObject')
+
 const { candleWidth } = require('bfx-hf-util')
 
 module.exports = ({
+  strategyId,
   label,
   symbol,
   timeframe,
   trades,
   candleSeed,
   margin,
+  strategyType,
   capitalAllocation,
   stopLossPerc,
   maxDrawdownPerc
 }) => {
-  if (!_isString(label)) {
+  if (!_isString(strategyId)) {
+    return 'Strategy id is not a string'
+  } else if (!_isString(label)) {
     return 'Label is not a string'
   } else if (!_isString(symbol)) {
     return 'Symbol is not a string'
@@ -28,6 +35,8 @@ module.exports = ({
     return 'Invalid seed candle count'
   } else if (!_isBoolean(margin)) {
     return 'Exchange/Margin trading value must be a boolean'
+  } else if (!_isNil(strategyType) && !_isPlainObject(strategyType)) {
+    return 'Invalid strategy type'
   } else if (!_isFinite(capitalAllocation)) {
     return 'Invalid strategy allocation'
   } else if (maxDrawdownPerc && !_isFinite(maxDrawdownPerc)) {


### PR DESCRIPTION
Task: https://app.asana.com/0/1201848935859401/1202458007891572

Read `strategyId` and `strategyType` from input parameters instead of the strategyContent.