### PR TITLE
defineIndicators should be optional

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
+++ b/lib/ws_servers/api/handlers/strategy/live_strategy_execution_start.js
@@ -52,15 +52,17 @@ module.exports = async (server, ws, msg) => {
   }
 
   try {
+    const indicators = strategy.defineIndicators
+      ? strategy.defineIndicators(Indicators)
+      : {}
+
     strategy = HFS.define({
       ...strategy,
       label,
       margin,
       tf: timeframe,
       symbol,
-      indicators: {
-        ...strategy.defineIndicators(Indicators)
-      }
+      indicators
     })
   } catch (e) {
     console.log(e)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
Otherwise, this will break strategies that don't have code definition for `defineIndicators`