### PR TITLE
fix leak: remove listeners from strategy executor

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -469,6 +469,7 @@ class StrategyManager {
 
     if (liveStrategyExecutor) {
       await liveStrategyExecutor.stopExecution()
+      liveStrategyExecutor.removeAllListeners()
       strategyExecutionResults = liveStrategyExecutor.generateResults()
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
Some resources like event emitters are not properly unsubscribed