### PR TITLE
fix: centralize messages

### DIFF
--- a/lib/ws_servers/api/send_authenticated.js
+++ b/lib/ws_servers/api/send_authenticated.js
@@ -58,21 +58,5 @@ module.exports = async (server, ws, opts) => {
   }])
   send(ws, ['data.api_credentials.configured', 'bitfinex'])
 
-  const results = await connectionManager.start(server, ws)
-  let status = {
-    dmsControl: false,
-    algoWorker: false,
-    bfxClient: false,
-    strategyManager: false
-  }
-
-  for (const { reason: err, value } of results) {
-    if (err) {
-      sendError(ws, `Failed to start services: ${err.message}`)
-    } else {
-      status = { ...status, ...value }
-    }
-  }
-
-  send(ws, ['info.services.status', mode, status])
+  await connectionManager.start(server, ws)
 }

--- a/lib/ws_servers/api/start_connections.js
+++ b/lib/ws_servers/api/start_connections.js
@@ -10,6 +10,8 @@ const createFilteredWs = require('./factories/created_filtered_ws')
 const createStrategyManager = require('./factories/create_strategy_manager')
 const getUserSettings = require('../../util/user_settings')
 const resendSnapshots = require('./snapshots/send_all')
+const sendError = require('../../util/ws/send_error')
+const send = require('../../util/ws/send')
 
 class ConnectionManager {
   constructor () {
@@ -36,15 +38,30 @@ class ConnectionManager {
     const { hasNewCredentials } = this._updateCredentials(session)
     const wsForMode = createFilteredWs(session)
 
-    return Promise.allSettled([
+    const results = await Promise.allSettled([
       this._startDmsControl(server, session),
       this._startAlgoWorker(server, session, wsForMode, hasNewCredentials),
       this._startStrategyManager(server, session, wsForMode),
       this._startBfxClient(server, session, wsForMode, hasNewCredentials)
     ])
-      .finally(() => {
-        this.debounce[mode] = false
-      })
+
+    let status = {
+      dmsControl: false,
+      algoWorker: false,
+      bfxClient: false,
+      strategyManager: false
+    }
+
+    for (const { reason: err, value } of results) {
+      if (err) {
+        sendError(wsForMode, `Failed to start services: ${err.message}`)
+      } else {
+        status = { ...status, ...value }
+      }
+    }
+
+    send(wsForMode, ['info.services.status', mode, status])
+    this.debounce[mode] = false
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
all events that start connections (`'auth.init`, `auth.submit`, `auth.change_mode`, `api_credentials.save`) should have the same responses, so let's centralize it.