### PR TITLE
set mode when not authenticated

### DIFF
--- a/lib/ws_servers/api/send_authenticated.js
+++ b/lib/ws_servers/api/send_authenticated.js
@@ -29,6 +29,7 @@ module.exports = async (server, ws, opts) => {
   notifySuccess(ws, 'Authenticated', ['authenticated'])
 
   if (!credentials) {
+    ws.mode = mode
     return
   }
 


### PR DESCRIPTION
There is a corner case where the user only authenticates in one of the modes and then switches, causing some messages from the incorrect mode to be sent.