### PR TITLE
fix abort strategy

### DIFF
--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -13,13 +13,12 @@ const { Manager, findChannelId, unsubscribe } = require('bfx-api-node-core')
 const {
   PriceFeed,
   PerformanceManager,
-  StartWatchers: startPerformanceWatchers,
-  ExitModes
+  StartWatchers: startPerformanceWatchers
 } = require('bfx-hf-strategy-perf')
 
 const { apply: applyI18N } = require('../../../../util/i18n')
 const { WD_PACKET_DELAY, WD_RECONNECT_DELAY } = require('../../../../constants')
-const { closeOpenPositions, closePendingOrders } = require('bfx-hf-strategy')
+const { closeOpenPositions } = require('bfx-hf-strategy')
 
 const debug = require('debug')('bfx:hf:server:strategy-manager')
 
@@ -159,7 +158,7 @@ class StrategyManager {
       console.error(error)
 
       const errorMessage = error.text || error
-      this._sendError(errorMessage, strategyMapKey, strategyOptions)
+      this._sendError(errorMessage)
 
       this.close(strategyMapKey)
     })
@@ -198,10 +197,8 @@ class StrategyManager {
   /**
    * @private
    * @param {Error|Object|*} err
-   * @param strategyMapKey
-   * @param label
    */
-  _sendError (err, strategyMapKey, { label }) {
+  _sendError (err) {
     this.pub(['notify', 'error', `Strategy Execution Error: ${err}`])
   }
 
@@ -356,11 +353,11 @@ class StrategyManager {
     strategy.isClosing = true
     const { liveStrategyExecutor } = strategy
 
-    await liveStrategyExecutor.invoke(
-      mode === ExitModes.KEEP_ASSETS
-        ? closePendingOrders
-        : closeOpenPositions
-    )
+    try {
+      await liveStrategyExecutor.invoke(closeOpenPositions)
+    } catch (e) {
+      this._sendError(e.message)
+    }
 
     await this.close(strategyMapKey)
   }

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -199,7 +199,8 @@ class StrategyManager {
    * @param {Error|Object|*} err
    */
   _sendError (err) {
-    this.pub(['notify', 'error', `Strategy Execution Error: ${err}`])
+    const msg = err.text || err.message || err
+    this.pub(['notify', 'error', `Strategy Execution Error: ${msg}`])
   }
 
   /**
@@ -356,7 +357,7 @@ class StrategyManager {
     try {
       await liveStrategyExecutor.invoke(closeOpenPositions)
     } catch (e) {
-      this._sendError(e.message)
+      this._sendError(e)
     }
 
     await this.close(strategyMapKey)
@@ -518,9 +519,13 @@ class StrategyManager {
     let strategyExecutionResults = {}
 
     if (liveStrategyExecutor) {
-      await liveStrategyExecutor.stopExecution()
-      liveStrategyExecutor.removeAllListeners()
-      strategyExecutionResults = liveStrategyExecutor.generateResults()
+      try {
+        await liveStrategyExecutor.stopExecution()
+        liveStrategyExecutor.removeAllListeners()
+        strategyExecutionResults = liveStrategyExecutor.generateResults()
+      } catch (e) {
+        this._sendError(e)
+      }
     }
 
     this.pub(['strategy.live_execution_results', strategyMapKey, strategyExecutionResults])

--- a/lib/ws_servers/api/handlers/strategy/strategy_manager.js
+++ b/lib/ws_servers/api/handlers/strategy/strategy_manager.js
@@ -18,7 +18,6 @@ const {
 
 const { apply: applyI18N } = require('../../../../util/i18n')
 const { WD_PACKET_DELAY, WD_RECONNECT_DELAY } = require('../../../../constants')
-const { closeOpenPositions } = require('bfx-hf-strategy')
 
 const debug = require('debug')('bfx:hf:server:strategy-manager')
 
@@ -344,7 +343,7 @@ class StrategyManager {
     return activeStrategyKeys.map(strategyMapKey => this._formatStrategy(strategyMapKey))
   }
 
-  async _abortStrategy (strategyMapKey, mode) {
+  async _abortStrategy (strategyMapKey) {
     const strategy = this.strategy.get(strategyMapKey)
 
     if (strategy.isClosing) {
@@ -352,13 +351,6 @@ class StrategyManager {
     }
 
     strategy.isClosing = true
-    const { liveStrategyExecutor } = strategy
-
-    try {
-      await liveStrategyExecutor.invoke(closeOpenPositions)
-    } catch (e) {
-      this._sendError(e)
-    }
 
     await this.close(strategyMapKey)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",


### PR DESCRIPTION
* live execution manager already takes care of closing the open positions; no need to close them twice
* handle errors when submitting orders