### PR TITLE
Reset API credentials for a given mode

### DIFF
--- a/lib/ws_servers/api/handlers/on_reset_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_reset_api_credentials.js
@@ -26,7 +26,7 @@ module.exports = async (server, ws, msg) => {
   const [credentials] = await Credential.find([['mode', '=', mode]])
 
   if (credentials) {
-    await Credential.set(credentials.cid)
+    await Credential.rm(credentials.cid)
   }
 
   send(ws, ['data.api_credentials.reset', true])

--- a/lib/ws_servers/api/handlers/on_reset_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_reset_api_credentials.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const send = require('../../../util/ws/send')
+const sendError = require('../../../util/ws/send_error')
+const validateParams = require('../../../util/ws/validate_params')
+
+const isAuthorized = require('../../../util/ws/is_authorized')
+
+module.exports = async (server, ws, msg) => {
+  const { d, db } = server
+  const { Credential } = db
+
+  const [, authToken, mode] = msg
+  const validRequest = validateParams(ws, {
+    authToken: { type: 'string', v: authToken },
+    mode: { type: 'string', v: mode }
+  })
+  if (!validRequest) {
+    d('reset credentials: invalid request')
+    return
+  }
+  if (!isAuthorized(ws, authToken)) {
+    return sendError(ws, 'Unauthorized')
+  }
+
+  const [credentials] = await Credential.find([['mode', '=', mode]])
+
+  if (credentials) {
+    await Credential.set(credentials.cid)
+  }
+
+  send(ws, ['data.api_credentials.reset', true])
+}

--- a/lib/ws_servers/api/handlers/on_reset_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_reset_api_credentials.js
@@ -29,5 +29,5 @@ module.exports = async (server, ws, msg) => {
     await Credential.rm(credentials.cid)
   }
 
-  send(ws, ['data.api_credentials.reset', true])
+  send(ws, ['data.api_credentials.reset', mode, true])
 }

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -16,6 +16,8 @@ const capture = require('../../../capture')
 const validateModes = require('../validate_modes')
 const connManager = require('../start_connections')
 
+const exID = 'bitfinex' // legacy support
+
 module.exports = async (server, ws, msg) => {
   const { d, db, restURL, reconnectAlgoHost } = server
   const [, authToken, apiKey, apiSecret, formSent, mode, dmsScope] = msg
@@ -26,8 +28,6 @@ module.exports = async (server, ws, msg) => {
     formSent: { type: 'string', v: formSent },
     mode: { type: 'string', v: mode }
   })
-
-  const exID = 'bitfinex' // legacy support
 
   if (!validRequest) {
     d('save credentials: invalid request')

--- a/lib/ws_servers/api/index.js
+++ b/lib/ws_servers/api/index.js
@@ -15,6 +15,7 @@ const onActiveAlgoOrdersRequest = require('./handlers/on_active_algo_orders_requ
 const onSaveStrategy = require('./handlers/on_save_strategy')
 const onRemoveStrategy = require('./handlers/on_remove_strategy')
 const onSaveAPICredentials = require('./handlers/on_save_api_credentials')
+const onResetAPICredentials = require('./handlers/on_reset_api_credentials')
 const onAlgoOrderRemove = require('./handlers/on_algo_order_remove')
 const onAlgoOrderLoad = require('./handlers/on_algo_order_load')
 const onOrderSubmit = require('./handlers/on_order_submit')
@@ -104,6 +105,7 @@ module.exports = class APIWSServer extends WSServer {
         'strategy.save': onSaveStrategy,
         'strategy.remove': onRemoveStrategy,
         'api_credentials.save': onSaveAPICredentials,
+        'api_credentials.reset': onResetAPICredentials,
         'order.submit': onOrderSubmit,
         'order.update': onOrderUpdate,
         'order.cancel': onOrderCancel,


### PR DESCRIPTION
Adds an endpoint to reset credentials.

Command: `["api_credentials.reset", authToken, mode]`

Response: `["data.api_credentials.reset", success (boolean)]`