### PR TITLE
retry fetching user info

### DIFF
--- a/lib/exchange_clients/bitfinex/index.js
+++ b/lib/exchange_clients/bitfinex/index.js
@@ -7,6 +7,7 @@ const debug = require('debug')('bfx:hf:server:exchange-clients:bitfinex')
 
 const recvMessage = require('./recv/message')
 const getMarkets = require('./get_markets')
+const capture = require('../../capture')
 
 const { DMS_ENABLED, WD_PACKET_DELAY, WD_RECONNECT_DELAY } = require('../../constants')
 
@@ -134,8 +135,20 @@ class BitfinexExchangeConnection {
     return getMarkets(this.rest)
   }
 
-  getUserInfo () {
-    return this.rest.userInfo()
+  async getUserInfo () {
+    let retry = 0
+    let err = null
+
+    while (retry < 3) {
+      try {
+        return await this.rest.userInfo()
+      } catch (e) {
+        err = e
+        retry++
+      }
+    }
+    if (err) capture.exception(err)
+    return null
   }
 }
 

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -59,8 +59,10 @@ module.exports = ({ ws, apiKey, apiSecret, authToken, dms, d, wsURL, restURL, is
   client.on('ws2:event:auth:success', async () => {
     notifySuccess(ws, 'Authenticated with Bitfinex', ['authenticatedWith', { target: 'Bitfinex' }])
     send(ws, ['data.client', 'bitfinex', WS_CONNECTION.OPENED])
-    const { username } = await client.getUserInfo()
-    send(ws, ['info.username', isPaper ? 'paper' : 'main', username])
+    const userInfo = await client.getUserInfo()
+    if (userInfo) {
+      send(ws, ['info.username', isPaper ? 'paper' : 'main', userInfo.username])
+    }
   })
 
   client.on('ws2:close', () => {


### PR DESCRIPTION
Sometimes, the bitfinex api throws `nonce:small` error causing this to not return user info when requested because the nonce should be sent in incrementing order. The logic [here](https://github.com/bitfinexcom/bfx-api-node-util/blob/master/lib/nonce.js) seems to be fine to not generate that error. However, for now, this is a workaround fix to avoid such error.

Task: https://app.asana.com/0/1201849173362898/1202867567995640 