### PR TITLE
reconnect only when in the same mode

### DIFF
--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -69,15 +69,14 @@ module.exports = async (server, ws, msg) => {
 
   d('issuing API & Algo reconnect due to credentials change')
 
-  ws.authenticateSession({
-    apiKey,
-    apiSecret,
-    mode,
-    dmsScope
-  })
-
   notifySuccess(ws, 'Reconnecting with new credentials...', ['reconnectingWithNewCredentials'])
 
-  await ws.closeMode(mode)
-  await connManager.start(server, ws)
+  await ws.closeMode(formSent)
+
+  if (formSent === mode) {
+    ws.authenticateSession({ mode, dmsScope, apiKey, apiSecret })
+    await connManager.start(server, ws)
+  } else {
+    ws.setCredentialsForMode(formSent, apiKey, apiSecret)
+  }
 }

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -69,11 +69,11 @@ module.exports = async (server, ws, msg) => {
 
   d('issuing API & Algo reconnect due to credentials change')
 
-  notifySuccess(ws, 'Reconnecting with new credentials...', ['reconnectingWithNewCredentials'])
-
   await ws.closeMode(formSent)
 
   if (formSent === mode) {
+    notifySuccess(ws, 'Reconnecting with new credentials...', ['reconnectingWithNewCredentials'])
+
     ws.authenticateSession({ mode, dmsScope, apiKey, apiSecret })
     await connManager.start(server, ws)
   } else {

--- a/lib/ws_servers/api/session.js
+++ b/lib/ws_servers/api/session.js
@@ -140,6 +140,10 @@ class Session {
     this.mode = mode
     this.dmsScope = dmsScope
     this.isPaper = mode === 'paper'
+    this.setCredentialsForMode(mode, apiKey, apiSecret)
+  }
+
+  setCredentialsForMode (mode, apiKey, apiSecret) {
     this.credentials[mode] = { apiKey, apiSecret }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-server",
-  "version": "7.9.3",
+  "version": "7.9.4",
   "description": "HF server bundle",
   "author": "Bitfinex",
   "license": "Apache-2.0",

--- a/test/unit/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/test/unit/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -151,7 +151,9 @@ describe('on save api credentials', () => {
       ['encryptedApiCredentialsSavedFor', { target: 'Bitfinex' }]
     )
     assert.calledWithExactly(stubWsSend, ws, ['data.api_credentials.configured', 'bitfinex'])
-    assert.notCalled(server.reconnectAlgoHost)
+    assert.calledWithExactly(ws.setCredentialsForMode, formSent, apiKey, apiSecret)
+    assert.notCalled(ws.authenticateSession)
+    assert.notCalled(stubStartConnections)
   })
 
   it('should start algo worker', async () => {

--- a/test/unit/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/test/unit/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -69,7 +69,8 @@ describe('on save api credentials', () => {
     authPassword: 'secret',
     authControl: 'auth control',
     closeMode: sandbox.stub(),
-    authenticateSession: sandbox.stub()
+    authenticateSession: sandbox.stub(),
+    setCredentialsForMode: sandbox.stub()
   }
   const authToken = 'authToken'
   const apiKey = 'apiKey'


### PR DESCRIPTION
use `formSent` to check if new credentials belong to the current mode.