### PR TITLE
Recurring: move logic of fetching to bfx auth success

### DIFF
--- a/lib/ws_servers/api/handlers/on_auth_init.js
+++ b/lib/ws_servers/api/handlers/on_auth_init.js
@@ -12,7 +12,6 @@ const {
 
 const sendStrategies = require('../send_strategies')
 const sendAuthenticated = require('../send_authenticated')
-const sendRecurringAlgoOrderList = require('../send_recurring_algo_order_list')
 
 module.exports = async (server, ws, msg) => {
   if (ws.authPassword) {
@@ -65,5 +64,4 @@ module.exports = async (server, ws, msg) => {
 
   await sendAuthenticated(server, ws, { mode, dmsScope })
   await sendStrategies(ws, db, d)
-  await sendRecurringAlgoOrderList(server, ws, mode)
 }

--- a/lib/ws_servers/api/handlers/on_auth_submit.js
+++ b/lib/ws_servers/api/handlers/on_auth_submit.js
@@ -9,7 +9,6 @@ const capture = require('../../../capture')
 const validateModes = require('../validate_modes')
 const sendStrategies = require('../send_strategies')
 const sendAuthenticated = require('../send_authenticated')
-const sendRecurringAlgoOrderList = require('../send_recurring_algo_order_list')
 
 let authenticating = false
 
@@ -60,7 +59,6 @@ module.exports = async (server, ws, msg) => {
   await validateModes(ws, db, { restURL })
   await sendAuthenticated(server, ws, { mode, dmsScope })
   await sendStrategies(ws, db, d)
-  await sendRecurringAlgoOrderList(server, ws, mode)
 
   const algoWorker = ws.getAlgoWorker()
   if (algoWorker) {

--- a/lib/ws_servers/api/handlers/on_change_mode.js
+++ b/lib/ws_servers/api/handlers/on_change_mode.js
@@ -1,5 +1,4 @@
 const sendAuthenticated = require('../send_authenticated')
-const sendRecurringAlgoOrderList = require('../send_recurring_algo_order_list')
 
 module.exports = async (server, ws, msg) => {
   const [, mode, dmsScope] = msg
@@ -9,5 +8,4 @@ module.exports = async (server, ws, msg) => {
   }
 
   await sendAuthenticated(server, ws, { mode, dmsScope })
-  await sendRecurringAlgoOrderList(server, ws, mode)
 }

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -22,7 +22,6 @@ const onPositionsSnapshot = require('./events/positions_snapshot')
 const onWalletUpdate = require('./events/wallet_update')
 const onWalletsSnapshot = require('./events/wallets_snapshot')
 const isAddrInfoError = require('../../util/is_addr_info_error')
-// const sendRecurringAlgoOrderList = require('./send_recurring_algo_order_list')
 
 module.exports = ({
   ws,
@@ -37,8 +36,7 @@ module.exports = ({
   dmsScope = 'app',
   sendDataToMetricsServer,
   mode,
-  session,
-  algoDB
+  session
 }) => {
   notifyInfo(ws, 'Connecting to Bitfinex...', [
     'connectingTo',
@@ -88,20 +86,6 @@ module.exports = ({
         userInfo.username
       ])
     }
-
-    // await sendRecurringAlgoOrderList(
-    //   {
-    //     d,
-    //     restURL,
-    //     algoDB
-    //   },
-    //   ws,
-    //   {
-    //     apiKey,
-    //     apiSecret
-    //   },
-    //   mode
-    // )
   })
 
   client.on('ws2:close', () => {

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -7,10 +7,7 @@ const {
   notifySuccess
 } = require('../../util/ws/notify')
 const send = require('../../util/ws/send')
-const {
-  WS_CONNECTION,
-  DMS_ENABLED
-} = require('../../constants')
+const { WS_CONNECTION, DMS_ENABLED } = require('../../constants')
 const onNotify = require('./events/notify')
 const onOrderClose = require('./events/order_close')
 const onOrderNew = require('./events/order_new')
@@ -22,6 +19,7 @@ const onPositionsSnapshot = require('./events/positions_snapshot')
 const onWalletUpdate = require('./events/wallet_update')
 const onWalletsSnapshot = require('./events/wallets_snapshot')
 const isAddrInfoError = require('../../util/is_addr_info_error')
+const sendRecurringAlgoOrderList = require('./send_recurring_algo_order_list')
 
 module.exports = ({
   ws,
@@ -36,7 +34,8 @@ module.exports = ({
   dmsScope = 'app',
   sendDataToMetricsServer,
   mode,
-  session
+  session,
+  algoDB
 }) => {
   notifyInfo(ws, 'Connecting to Bitfinex...', [
     'connectingTo',
@@ -86,6 +85,19 @@ module.exports = ({
         userInfo.username
       ])
     }
+    await sendRecurringAlgoOrderList(
+      {
+        d,
+        restURL,
+        algoDB
+      },
+      ws,
+      {
+        apiKey,
+        apiSecret
+      },
+      mode
+    )
   })
 
   client.on('ws2:close', () => {

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -89,19 +89,19 @@ module.exports = ({
       ])
     }
 
-    await sendRecurringAlgoOrderList(
-      {
-        d,
-        restURL,
-        algoDB
-      },
-      ws,
-      {
-        apiKey,
-        apiSecret
-      },
-      mode
-    )
+    // await sendRecurringAlgoOrderList(
+    //   {
+    //     d,
+    //     restURL,
+    //     algoDB
+    //   },
+    //   ws,
+    //   {
+    //     apiKey,
+    //     apiSecret
+    //   },
+    //   mode
+    // )
   })
 
   client.on('ws2:close', () => {

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -88,7 +88,7 @@ module.exports = ({
         userInfo.username
       ])
     }
-    console.log('auth success')
+
     await sendRecurringAlgoOrderList(
       {
         d,

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -22,7 +22,7 @@ const onPositionsSnapshot = require('./events/positions_snapshot')
 const onWalletUpdate = require('./events/wallet_update')
 const onWalletsSnapshot = require('./events/wallets_snapshot')
 const isAddrInfoError = require('../../util/is_addr_info_error')
-const sendRecurringAlgoOrderList = require('./send_recurring_algo_order_list')
+// const sendRecurringAlgoOrderList = require('./send_recurring_algo_order_list')
 
 module.exports = ({
   ws,

--- a/lib/ws_servers/api/open_auth_bitfinex_connection.js
+++ b/lib/ws_servers/api/open_auth_bitfinex_connection.js
@@ -22,9 +22,28 @@ const onPositionsSnapshot = require('./events/positions_snapshot')
 const onWalletUpdate = require('./events/wallet_update')
 const onWalletsSnapshot = require('./events/wallets_snapshot')
 const isAddrInfoError = require('../../util/is_addr_info_error')
+const sendRecurringAlgoOrderList = require('./send_recurring_algo_order_list')
 
-module.exports = ({ ws, apiKey, apiSecret, authToken, dms, d, wsURL, restURL, isPaper, dmsScope = 'app', sendDataToMetricsServer, mode, session }) => {
-  notifyInfo(ws, 'Connecting to Bitfinex...', ['connectingTo', { target: 'Bitfinex' }])
+module.exports = ({
+  ws,
+  apiKey,
+  apiSecret,
+  authToken,
+  dms,
+  d,
+  wsURL,
+  restURL,
+  isPaper,
+  dmsScope = 'app',
+  sendDataToMetricsServer,
+  mode,
+  session,
+  algoDB
+}) => {
+  notifyInfo(ws, 'Connecting to Bitfinex...', [
+    'connectingTo',
+    { target: 'Bitfinex' }
+  ])
 
   const client = new BitfinexExchangeConnection({ wsURL, restURL })
 
@@ -40,11 +59,7 @@ module.exports = ({ ws, apiKey, apiSecret, authToken, dms, d, wsURL, restURL, is
     apiKey,
     apiSecret,
     authToken,
-    channelFilters: [
-      'trading',
-      'wallet',
-      'notify'
-    ]
+    channelFilters: ['trading', 'wallet', 'notify']
   })
 
   client.on('ws2:error', (err) => {
@@ -53,24 +68,51 @@ module.exports = ({ ws, apiKey, apiSecret, authToken, dms, d, wsURL, restURL, is
   })
 
   client.on('ws2:open', () => {
-    notifyInfo(ws, 'Connected to Bitfinex', ['connectedTo', { target: 'Bitfinex' }])
+    notifyInfo(ws, 'Connected to Bitfinex', [
+      'connectedTo',
+      { target: 'Bitfinex' }
+    ])
   })
 
   client.on('ws2:event:auth:success', async () => {
-    notifySuccess(ws, 'Authenticated with Bitfinex', ['authenticatedWith', { target: 'Bitfinex' }])
+    notifySuccess(ws, 'Authenticated with Bitfinex', [
+      'authenticatedWith',
+      { target: 'Bitfinex' }
+    ])
     send(ws, ['data.client', 'bitfinex', mode, WS_CONNECTION.OPENED])
     const userInfo = await client.getUserInfo()
     if (userInfo) {
-      send(ws, ['info.username', isPaper ? 'paper' : 'main', userInfo.username])
+      send(ws, [
+        'info.username',
+        isPaper ? 'paper' : 'main',
+        userInfo.username
+      ])
     }
+    console.log('auth success')
+    await sendRecurringAlgoOrderList(
+      {
+        d,
+        restURL,
+        algoDB
+      },
+      ws,
+      {
+        apiKey,
+        apiSecret
+      },
+      mode
+    )
   })
 
   client.on('ws2:close', () => {
-    notifyInfo(ws, 'Disconnected from Bitfinex', ['disconnectedFrom', { target: 'Bitfinex' }])
+    notifyInfo(ws, 'Disconnected from Bitfinex', [
+      'disconnectedFrom',
+      { target: 'Bitfinex' }
+    ])
     send(ws, ['data.client', 'bitfinex', mode, WS_CONNECTION.CLOSED])
   })
 
-  client.onData(payload => {
+  client.onData((payload) => {
     const [msgType, msgData] = payload
 
     switch (msgType) {
@@ -93,13 +135,34 @@ module.exports = ({ ws, apiKey, apiSecret, authToken, dms, d, wsURL, restURL, is
         return onOrdersSnapshot(ws, isPaper, dmsScope, msgData)
       }
       case 'on': {
-        return onOrderNew(ws, isPaper, dmsScope, msgData, sendDataToMetricsServer, session)
+        return onOrderNew(
+          ws,
+          isPaper,
+          dmsScope,
+          msgData,
+          sendDataToMetricsServer,
+          session
+        )
       }
       case 'ou': {
-        return onOrderUpdate(ws, isPaper, dmsScope, msgData, sendDataToMetricsServer, session)
+        return onOrderUpdate(
+          ws,
+          isPaper,
+          dmsScope,
+          msgData,
+          sendDataToMetricsServer,
+          session
+        )
       }
       case 'oc': {
-        return onOrderClose(ws, isPaper, dmsScope, msgData, sendDataToMetricsServer, session)
+        return onOrderClose(
+          ws,
+          isPaper,
+          dmsScope,
+          msgData,
+          sendDataToMetricsServer,
+          session
+        )
       }
       case 'n': {
         return onNotify(ws, msgData)

--- a/lib/ws_servers/api/send_recurring_algo_order_list.js
+++ b/lib/ws_servers/api/send_recurring_algo_order_list.js
@@ -67,9 +67,9 @@ const getAndUpdateRecurringAlgoOrdersList = async (rest, algoDB) => {
   return activeRecurringAOs
 }
 
-module.exports = async (server, ws, mode) => {
+module.exports = async (server, ws, credentials, mode) => {
   const { d, restURL, algoDB } = server
-  const { apiKey, apiSecret } = ws.getCredentials()
+  const { apiKey, apiSecret } = credentials
 
   if (!apiKey || !apiSecret) {
     return

--- a/lib/ws_servers/api/start_connections.js
+++ b/lib/ws_servers/api/start_connections.js
@@ -198,7 +198,7 @@ class ConnectionManager {
    * @private
    */
   async _startBfxClient (server, session, ws, shouldUpdate = false) {
-    const { d, wsURL, restURL } = server
+    const { d, wsURL, restURL, algoDB } = server
 
     let client = session.getClient()
     if (client && client.isOpen && !shouldUpdate) {
@@ -221,7 +221,8 @@ class ConnectionManager {
       dms: false,
       sendDataToMetricsServer,
       mode,
-      session
+      session,
+      algoDB
     })
     session.setClient(client)
 

--- a/test/unit/lib/ws_servers/api/start_connections.js
+++ b/test/unit/lib/ws_servers/api/start_connections.js
@@ -43,6 +43,7 @@ describe('ConnectionManager', () => {
   const sessionId = 'session_id'
   const db = sandbox.stub()
   const d = sandbox.stub()
+  const algoDB = sandbox.stub()
   const apiKey = 'api key'
   const apiSecret = 'api secret'
   const wsURL = 'ws url'
@@ -54,7 +55,8 @@ describe('ConnectionManager', () => {
     db,
     d,
     wsURL,
-    restURL
+    restURL,
+    algoDB
   }
   const session = {
     id: sessionId,
@@ -158,7 +160,8 @@ describe('ConnectionManager', () => {
       dms: false,
       sendDataToMetricsServer: session.sendDataToMetricsServer,
       mode,
-      session
+      session,
+      algoDB
     })
     assert.calledWithExactly(session.setClient, bfxClient)
 
@@ -195,7 +198,8 @@ describe('ConnectionManager', () => {
       dms: false,
       sendDataToMetricsServer: paperSession.sendDataToMetricsServer,
       mode,
-      session: paperSession
+      session: paperSession,
+      algoDB
     })
 
     expect(manager.credentials.paper.apiKey).to.be.eq(apiKey)
@@ -274,7 +278,8 @@ describe('ConnectionManager', () => {
       dms: false,
       sendDataToMetricsServer: session.sendDataToMetricsServer,
       mode,
-      session
+      session,
+      algoDB
     })
 
     expect(manager.credentials.main.apiKey).to.be.eq(apiKey)


### PR DESCRIPTION
ticket - https://app.asana.com/0/1201849173362898/1204015342388113
it sends recurring AOs on auth, on connection reload, on api keys submit 