### PR TITLE
fix: algoworker mode issue

### DIFF
--- a/lib/ws_servers/api/handlers/on_selected_algo_resume_remove.js
+++ b/lib/ws_servers/api/handlers/on_selected_algo_resume_remove.js
@@ -1,10 +1,11 @@
 'use strict'
 
+const _isArray = require('lodash/isArray')
 const send = require('../../../util/ws/send')
 const validateParams = require('../../../util/ws/validate_params')
 const isAuthorized = require('../../../util/ws/is_authorized')
 const sendError = require('../../../util/ws/send_error')
-const startAlgoWorkerForMode = require('../start_algoworker_for_mode')
+const sendAuthenticated = require('../send_authenticated')
 
 const resumeAOs = async (server, session, algoWorker, mode, payload) => {
   const { d, algoDB } = server
@@ -68,9 +69,28 @@ const removeAOs = async (server, session, algoWorker, mode, payload) => {
   d('removed selected orders %s', JSON.stringify(removedOrders))
 }
 
+const isPayloadModeEmpty = (payload, mode) => {
+  if (!payload[mode]) {
+    return true
+  }
+
+  const resume = payload[mode].resume
+  const remove = payload[mode].remove
+  if (
+    (_isArray(resume) && resume.length > 0) ||
+    (_isArray(remove) && remove.length > 0)
+  ) {
+    return false
+  }
+
+  return true
+}
+
 module.exports = async (server, session, msg) => {
   const { d } = server
   const [, authToken, payload] = msg
+  const { mode: currentMode } = session
+  let switchedMode = currentMode
 
   const validRequest = validateParams(session, {
     authToken: { type: 'string', v: authToken },
@@ -87,15 +107,25 @@ module.exports = async (server, session, msg) => {
   }
 
   for (let [mode, { algoWorker }] of Object.entries(session.services)) {
+    if (isPayloadModeEmpty(payload, mode)) {
+      continue
+    }
+
     // if algoWorker is not running, start it
     if (!algoWorker) {
-      await startAlgoWorkerForMode(server, session, { mode, dmsScope: session.dmsScope })
+      await sendAuthenticated(server, session, { mode, dmsScope: session.dmsScope })
       algoWorker = session.services[mode].algoWorker
+
+      switchedMode = mode
     }
 
     if (algoWorker) {
       await removeAOs(server, session, algoWorker, mode, payload)
       await resumeAOs(server, session, algoWorker, mode, payload)
     }
+  }
+
+  if (switchedMode !== currentMode) {
+    await sendAuthenticated(server, session, { mode: currentMode, dmsScope: session.dmsScope })
   }
 }


### PR DESCRIPTION
> The changes

- It tracks the current user mode
- it uses existing **sendAuthenticated** method to switch the mode (used in change mode handler)
- if the payload is empty for a given mode for that mode it won't start the algoworker
- if it switches the mode to start algoworker for other mode (to resume/remove AOs regardless of current mode) it tracks the swithced mode
- at last, comparing the swtiched mode it will revert back to current user mode so that user can work properly without switching the mode again.