### PR TITLE
(feature) Stop active AOs on API keys change

### DIFF
--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -165,7 +165,7 @@ class AlgoWorker {
       })
   }
 
-  async closeActiveAlgosOnHost () {
+  async _closeActiveAlgosOnHost () {
     const promises = []
     this.host.getAOInstances()
       .forEach((aoInstance) => {
@@ -183,7 +183,7 @@ class AlgoWorker {
    * @public
    */
   async close () {
-    await this.closeActiveAlgosOnHost()
+    await this._closeActiveAlgosOnHost()
 
     this.isOpen = false
     if (this.host) {

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -176,7 +176,7 @@ class AlgoWorker {
         }
         promises.push(this.cancelOrder(gid))
       })
-    await Promise.all(promises)
+    await Promise.allSettled(promises)
   }
 
   /**

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -165,7 +165,7 @@ class AlgoWorker {
       })
   }
 
-  async _closeActiveAlgosOnHost () {
+  async closeActiveAlgosOnHost () {
     const promises = []
     this.host.getAOInstances()
       .forEach((aoInstance) => {
@@ -182,9 +182,7 @@ class AlgoWorker {
   /**
    * @public
    */
-  async close () {
-    await this._closeActiveAlgosOnHost()
-
+  close () {
     this.isOpen = false
     if (this.host) {
       this.host.removeAllListeners()

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -87,7 +87,9 @@ class AlgoWorker {
         .map((str) => `"${str}"`)
         .join(', ')
 
-      throw new Error(`The given API key does not have the required permissions, please make sure to enable ${permissionList}`)
+      throw new Error(
+        `The given API key does not have the required permissions, please make sure to enable ${permissionList}`
+      )
     }
 
     d('spawned host for %s', userId)
@@ -157,18 +159,32 @@ class AlgoWorker {
   }
 
   getActiveAlgosFromHost () {
-    return this.host.getAOInstances()
-      .filter((aoInstance) => {
-        const { state = {} } = aoInstance
-        const { active } = state
-        return active
-      })
+    return this.host.getAOInstances().filter((aoInstance) => {
+      const { state = {} } = aoInstance
+      const { active } = state
+      return active
+    })
+  }
+
+  async closeActiveAlgosOnHost () {
+    const promises = []
+    this.host.getAOInstances().forEach((aoInstance) => {
+      const { state = {} } = aoInstance
+      const { gid, active } = state
+      if (!active) {
+        return
+      }
+      promises.push(this.cancelOrder(gid))
+    })
+    await Promise.all(promises)
   }
 
   /**
    * @public
    */
-  close () {
+  async close () {
+    await this.closeActiveAlgosOnHost()
+
     this.isOpen = false
     if (this.host) {
       this.host.removeAllListeners()

--- a/lib/ws_servers/api/algos/algo_worker.js
+++ b/lib/ws_servers/api/algos/algo_worker.js
@@ -87,9 +87,7 @@ class AlgoWorker {
         .map((str) => `"${str}"`)
         .join(', ')
 
-      throw new Error(
-        `The given API key does not have the required permissions, please make sure to enable ${permissionList}`
-      )
+      throw new Error(`The given API key does not have the required permissions, please make sure to enable ${permissionList}`)
     }
 
     d('spawned host for %s', userId)
@@ -159,23 +157,25 @@ class AlgoWorker {
   }
 
   getActiveAlgosFromHost () {
-    return this.host.getAOInstances().filter((aoInstance) => {
-      const { state = {} } = aoInstance
-      const { active } = state
-      return active
-    })
+    return this.host.getAOInstances()
+      .filter((aoInstance) => {
+        const { state = {} } = aoInstance
+        const { active } = state
+        return active
+      })
   }
 
   async closeActiveAlgosOnHost () {
     const promises = []
-    this.host.getAOInstances().forEach((aoInstance) => {
-      const { state = {} } = aoInstance
-      const { gid, active } = state
-      if (!active) {
-        return
-      }
-      promises.push(this.cancelOrder(gid))
-    })
+    this.host.getAOInstances()
+      .forEach((aoInstance) => {
+        const { state = {} } = aoInstance
+        const { gid, active } = state
+        if (!active) {
+          return
+        }
+        promises.push(this.cancelOrder(gid))
+      })
     await Promise.all(promises)
   }
 

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -81,7 +81,8 @@ module.exports = async (server, ws, msg) => {
   send(ws, ['data.api_credentials.configured', exID])
 
   d('issuing API & Algo reconnect due to credentials change')
-
+  
+  await ws.getAlgoWorker().closeActiveAlgosOnHost()
   await ws.closeMode(formSent)
 
   if (formSent === mode) {

--- a/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -81,7 +81,7 @@ module.exports = async (server, ws, msg) => {
   send(ws, ['data.api_credentials.configured', exID])
 
   d('issuing API & Algo reconnect due to credentials change')
-  
+
   await ws.getAlgoWorker().closeActiveAlgosOnHost()
   await ws.closeMode(formSent)
 

--- a/test/unit/lib/ws_servers/api/handlers/on_save_api_credentials.js
+++ b/test/unit/lib/ws_servers/api/handlers/on_save_api_credentials.js
@@ -68,7 +68,8 @@ describe('on save api credentials', () => {
     hostedURL
   }
   const algoWorker = {
-    updateAuthArgs: sandbox.stub()
+    updateAuthArgs: sandbox.stub(),
+    closeActiveAlgosOnHost: sandbox.stub()
   }
   const ws = {
     authPassword: 'secret',
@@ -76,7 +77,8 @@ describe('on save api credentials', () => {
     closeMode: sandbox.stub(),
     authenticateSession: sandbox.stub(),
     setCredentialsForMode: sandbox.stub(),
-    sendDataToMetricsServer: sandbox.stub()
+    sendDataToMetricsServer: sandbox.stub(),
+    getAlgoWorker: () => algoWorker
   }
   const authToken = 'authToken'
   const apiKey = 'apiKey'
@@ -158,6 +160,7 @@ describe('on save api credentials', () => {
       ['encryptedApiCredentialsSavedFor', { target: 'Bitfinex' }]
     )
     assert.calledWithExactly(stubWsSend, ws, ['data.api_credentials.configured', 'bitfinex'])
+    assert.calledOnce(algoWorker.closeActiveAlgosOnHost)
     assert.calledWithExactly(ws.setCredentialsForMode, formSent, apiKey, apiSecret)
     assert.notCalled(ws.authenticateSession)
     assert.notCalled(stubStartConnections)
@@ -169,6 +172,7 @@ describe('on save api credentials', () => {
 
     await Handler(server, ws, msg)
 
+    assert.calledOnce(algoWorker.closeActiveAlgosOnHost)
     assert.calledWithExactly(ws.closeMode, mode)
     assert.calledWithExactly(ws.authenticateSession, {
       apiKey,


### PR DESCRIPTION
AO canceled correctly, but there is an error in the logs

[0] 2023-04-27T21:45:20.043Z bfx:hf:server:ws-server:api issuing API & Algo reconnect due to credentials change
[0] 2023-04-27T21:45:20.045Z bfx:hf:server:algo-worker ao instance updated 4794738212864
[0] 2023-04-27T21:45:20.045Z bfx:hf:algo:ao-host triggering life:stop for AO bfx-ping_pong [gid 4794738212864]
[0] 2023-04-27T21:45:20.045Z bfx:hf:algo:bfx-ping_pong:4794738212864 detected ping/pong algo cancellation, stopping...
[0] 2023-04-27T21:45:20.045Z bfx:hf:algo:bfx-ping_pong:4794738212864 emit exec:order:cancel:all [at onLifeStop (/home/dmytro/codecare/bfx-hf-server/node_modules/bfx-hf-algo/lib/ping_pong/events/life_stop.js:26:10)]
[0] 2023-04-27T21:45:20.046Z bfx:hf:algo:bfx-ping_pong:4794738212864 canceling order EXCHANGE LIMIT 0.005 @ 123 [cid 4794738212865 id 1866814474]
[0] 2023-04-27T21:45:20.046Z bfx:hf:algo:bfx-ping_pong:4794738212864 cancelOrder: (id: 1866814474) (cid: 4794738212865) EXCHANGE LIMIT order on BTC/USD (ACTIVE) for 0.00500000 @ 123.00 [aff-code: xZvWHMNR] [at /home/dmytro/codecare/bfx-hf-server/node_modules/bfx-hf-algo/lib/host/events/cancel_all_orders.js:40:25]
[0] 2023-04-27T21:45:20.047Z bfx:hf:server:algo-worker spawning bfx algo host (dms disabled) [aff xZvWHMNR]
[0] 2023-04-27T21:45:20.048Z bfx:hf:server:ws-server:api opening auth bfx connection (dms disabled)
[0] 2023-04-27T21:45:20.053Z bfx:hf:server:algo-worker ao instance updated 4794738212864
[0] 2023-04-27T21:45:20.053Z bfx:hf:server:algo-worker stopped AO for user HF_User on gid: 4794738212864
[0] 2023-04-27T21:45:20.377Z bfx:hf:algo:ao-host:ws2:bind-bus enqueue open
[0] 2023-04-27T21:45:20.377Z bfx:hf:algo:ao-host:ws2:process-message process open
[0] 2023-04-27T21:45:20.446Z bfx:hf:algo:ao-host:ws2:bind-bus enqueue auth:success
[0] 2023-04-27T21:45:20.446Z bfx:hf:algo:ao-host:ws2:process-message process auth:success
[0] 2023-04-27T21:45:20.446Z bfx:hf:server:algo-worker spawned host for HF_User
[0] 2023-04-27T21:45:20.446Z bfx:hf:algo:ao-host:ws2:bind-bus enqueue order:snapshot
[0] 2023-04-27T21:45:20.446Z bfx:hf:algo:ao-host:ws2:process-message process order:snapshot
[0] websocket error: Failed to start services: auth timeout
**[0] 2023-04-27T21:45:23.047Z bfx:hf:algo:bfx-ping_pong:4794738212864 received error while canceling order(id: 1866814474, cid: 4794738212865): EXCHANGE LIMIT 0.005 @ 123 [ERROR: Error: Response timeout for n:oc-req:1866814474:success and n:oc-req:1866814474:error**
[0]     at Timeout.<anonymous> (/home/dmytro/codecare/bfx-hf-server/node_modules/bfx-hf-algo/node_modules/bfx-api-node-core/lib/util/watch_response.js:32:14)
[0]     at listOnTimeout (internal/timers.js:557:17)
[0]     at processTimers (internal/timers.js:500:7)]
[0] Unhandled rejection: auth timeout
[0] Unhandled rejection: auth timeout
[0] ! process.<anonymous> -> process (/home/dmytro/codecare/bfx-hf-ui/node_modules/bfx-hf-util/lib/catch_uncaught_errors.js) [41:%s]
[0] ! emit -> process (events.js) [412:%s]
[0] ! processPromiseRejections -> null (internal/process/promises.js) [245:%s]
[0] ! processTicksAndRejections -> process (internal/process/task_queues.js) [96:%s]
[0] ! process.<anonymous> -> process (/home/dmytro/codecare/bfx-hf-server/node_modules/bfx-hf-util/lib/catch_uncaught_errors.js) [41:%s]
[0] ! emit -> process (events.js) [412:%s]
[0] ! processPromiseRejections -> null (internal/process/promises.js) [245:%s]
[0] ! processTicksAndRejections -> process (internal/process/task_queues.js) [96:%s]

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204086535291769