### PR TITLE
Fetch recurring aos list and atomic orders list with retries 

### DIFF
--- a/lib/util/rest_pagination_handler.js
+++ b/lib/util/rest_pagination_handler.js
@@ -12,10 +12,24 @@
 const restPaginationHandler = async (requestCallback, params = {}) => {
   let page = 1
   let collection = []
+  let retries = 0
+  let err = null
 
   while (true) {
     const payload = { page, limit: 50, ...params }
-    const result = await requestCallback(payload)
+    let result = null
+
+    while (retries < 3) {
+      try {
+        result = await requestCallback(payload)
+        if (result) break
+      } catch (e) {
+        console.error(e)
+        err = e
+        retries++
+      }
+    }
+
     if (!result || !result.items) break
 
     const { items } = result
@@ -25,6 +39,8 @@ const restPaginationHandler = async (requestCallback, params = {}) => {
 
     page += 1
   }
+
+  if (collection.length === 0 && err) throw err
 
   return collection
 }

--- a/lib/ws_servers/api/send_recurring_algo_order_list.js
+++ b/lib/ws_servers/api/send_recurring_algo_order_list.js
@@ -6,26 +6,6 @@ const sendError = require('../../util/ws/send_error')
 const mapRecurringAlgoOrderState = require('../../util/map_recurring_ao_state')
 const restPaginationHandler = require('../../util/rest_pagination_handler')
 
-const getRecurringAosWithRetry = async (rest, debug) => {
-  let algoOrders = []
-  let retries = 0
-  let err = null
-  while (retries < 3) {
-    try {
-      algoOrders = await restPaginationHandler(rest.getRecurringAlgoOrders.bind(rest), {})
-      debug('fetched total Recurring AOs', algoOrders.length)
-      return algoOrders
-    } catch (e) {
-      debug('error fetching Recurring AOs', e)
-      err = e
-      retries++
-    }
-  }
-  if (err) throw err
-
-  return algoOrders
-}
-
 /**
  * Get all recurring algo order list
  *
@@ -35,7 +15,8 @@ const getRecurringAosWithRetry = async (rest, debug) => {
  * @returns {Promise} p
  */
 const getAndUpdateRecurringAlgoOrdersList = async (rest, algoDB, debug) => {
-  const algoOrders = await getRecurringAosWithRetry(rest, debug)
+  const algoOrders = await restPaginationHandler(rest.getRecurringAlgoOrders.bind(rest), {})
+  debug('fetched total Recurring AOs', algoOrders.length)
 
   const { AlgoOrder } = algoDB
 


### PR DESCRIPTION
Fetch recurring aos list and atomic orders list with retries if api call fails. Mostly fails due to nonce error.